### PR TITLE
Global Constants

### DIFF
--- a/packages/v3/contracts/utility/Constants.sol
+++ b/packages/v3/contracts/utility/Constants.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity 0.7.6;
+
+uint256 constant MAX_UINT256 = uint256(-1);
+uint32 constant PPM_RESOLUTION = 1000000;

--- a/packages/v3/contracts/utility/MathEx.sol
+++ b/packages/v3/contracts/utility/MathEx.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.7.6;
 
+import "./Constants.sol";
+
 /**
  * @dev this library provides a set of complex math operations
  */
 library MathEx {
-    uint256 private constant MAX_UINT256 = uint256(-1);
-
     /**
      * @dev returns the largest integer smaller than or equal to the square root of a positive integer
      */

--- a/packages/v3/contracts/utility/Utils.sol
+++ b/packages/v3/contracts/utility/Utils.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.7.6;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./Constants.sol";
 
 /**
  * @dev common utilities
  */
 contract Utils {
-    uint32 internal constant PPM_RESOLUTION = 1000000;
-
     // verifies that a value is greater than zero
     modifier greaterThanZero(uint256 value) {
         _greaterThanZero(value);


### PR DESCRIPTION
1. Move all general-purpose constants to global scope
2. Remove redundant import of `IERC20` in `Utils.sol`
