### PR TITLE
Fix contract deploy param types

### DIFF
--- a/packages/v3/components/Contracts.ts
+++ b/packages/v3/components/Contracts.ts
@@ -32,14 +32,14 @@ export type Contract<F extends ContractFactory> = AsyncReturnType<F['deploy']>;
 
 export interface ContractBuilder<F extends ContractFactory> {
     contractName: string;
-    deploy(...args: Array<any>): Promise<Contract<F>>;
+    deploy(...args: Parameters<F['deploy']>): Promise<Contract<F>>;
     attach(address: string, passedSigner?: Signer): Promise<Contract<F>>;
 }
 
 const deployOrAttach = <F extends ContractFactory>(contractName: string, passedSigner?: Signer): ContractBuilder<F> => {
     return {
         contractName,
-        deploy: async (...args: Parameters<any>): Promise<Contract<F>> => {
+        deploy: async (...args: Parameters<F['deploy']>): Promise<Contract<F>> => {
             let defaultSigner = passedSigner ? passedSigner : (await ethers.getSigners())[0];
 
             return (await ethers.getContractFactory(contractName, defaultSigner)).deploy(

--- a/packages/v3/test/helpers/Factory.ts
+++ b/packages/v3/test/helpers/Factory.ts
@@ -42,7 +42,7 @@ const createLogic = async <F extends ContractFactory>(factory: ContractBuilder<F
         return cached.contract;
     }
 
-    const logicContract = await factory.deploy(...(ctorArgs || []));
+    const logicContract = await (factory.deploy as Function)(...(ctorArgs || []));
     logicContractsCache[factory.contractName] = { ctorArgs, contract: logicContract };
 
     return logicContract;


### PR DESCRIPTION
A previous PR removed the parameters typing on Contracts deploy. This fixes it.