### PR TITLE
Solidity 0.8.9: remove the override modifier from functions that override only a single interface function

### DIFF
--- a/packages/v3/contracts/helpers/TestUpgradeable.sol
+++ b/packages/v3/contracts/helpers/TestUpgradeable.sol
@@ -18,7 +18,7 @@ contract TestUpgradeable is Upgradeable {
 
     function __TestUpgradeable_init_unchained() internal initializer {}
 
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 

--- a/packages/v3/contracts/network/BancorNetwork.sol
+++ b/packages/v3/contracts/network/BancorNetwork.sol
@@ -356,84 +356,84 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function networkToken() external view override returns (IERC20) {
+    function networkToken() external view returns (IERC20) {
         return _networkToken;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function networkTokenGovernance() external view override returns (ITokenGovernance) {
+    function networkTokenGovernance() external view returns (ITokenGovernance) {
         return _networkTokenGovernance;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function govToken() external view override returns (IERC20) {
+    function govToken() external view returns (IERC20) {
         return _govToken;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function govTokenGovernance() external view override returns (ITokenGovernance) {
+    function govTokenGovernance() external view returns (ITokenGovernance) {
         return _govTokenGovernance;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function settings() external view override returns (INetworkSettings) {
+    function settings() external view returns (INetworkSettings) {
         return _settings;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function vault() external view override returns (IBancorVault) {
+    function vault() external view returns (IBancorVault) {
         return _vault;
     }
 
     /**
      * @dev IBancorNetwork
      */
-    function networkPoolToken() external view override returns (IPoolToken) {
+    function networkPoolToken() external view returns (IPoolToken) {
         return _networkPoolToken;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function networkTokenPool() external view override returns (INetworkTokenPool) {
+    function networkTokenPool() external view returns (INetworkTokenPool) {
         return _networkTokenPool;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function pendingWithdrawals() external view override returns (IPendingWithdrawals) {
+    function pendingWithdrawals() external view returns (IPendingWithdrawals) {
         return _pendingWithdrawals;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function poolCollectionUpgrader() external view override returns (IPoolCollectionUpgrader) {
+    function poolCollectionUpgrader() external view returns (IPoolCollectionUpgrader) {
         return _poolCollectionUpgrader;
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function externalProtectionWallet() external view override returns (ITokenHolder) {
+    function externalProtectionWallet() external view returns (ITokenHolder) {
         return _externalProtectionWallet;
     }
 
@@ -567,7 +567,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @inheritdoc IBancorNetwork
      */
-    function poolCollections() external view override returns (IPoolCollection[] memory) {
+    function poolCollections() external view returns (IPoolCollection[] memory) {
         uint256 length = _poolCollections.length();
         IPoolCollection[] memory list = new IPoolCollection[](length);
         for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
@@ -579,14 +579,14 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @inheritdoc IBancorNetwork
      */
-    function latestPoolCollection(uint16 poolType) external view override returns (IPoolCollection) {
+    function latestPoolCollection(uint16 poolType) external view returns (IPoolCollection) {
         return _latestPoolCollections[poolType];
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function liquidityPools() external view override returns (ReserveToken[] memory) {
+    function liquidityPools() external view returns (ReserveToken[] memory) {
         uint256 length = _liquidityPools.length();
         ReserveToken[] memory list = new ReserveToken[](length);
         for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
@@ -598,14 +598,14 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @inheritdoc IBancorNetwork
      */
-    function collectionByPool(ReserveToken pool) external view override returns (IPoolCollection) {
+    function collectionByPool(ReserveToken pool) external view returns (IPoolCollection) {
         return _collectionByPool[pool];
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function isPoolValid(ReserveToken pool) external view override returns (bool) {
+    function isPoolValid(ReserveToken pool) external view returns (bool) {
         return
             ReserveToken.unwrap(pool) == address(_networkToken) || _liquidityPools.contains(ReserveToken.unwrap(pool));
     }
@@ -615,7 +615,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
      */
     function createPool(uint16 poolType, ReserveToken reserveToken)
         external
-        override
         nonReentrant
         validAddress(ReserveToken.unwrap(reserveToken))
     {
@@ -646,7 +645,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @inheritdoc IBancorNetwork
      */
-    function upgradePools(ReserveToken[] calldata pools) external override nonReentrant {
+    function upgradePools(ReserveToken[] calldata pools) external nonReentrant {
         uint256 length = pools.length;
         for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
             ReserveToken pool = pools[i];
@@ -672,7 +671,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     )
         external
         payable
-        override
         validAddress(provider)
         validAddress(ReserveToken.unwrap(pool))
         greaterThanZero(tokenAmount)
@@ -687,7 +685,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     function deposit(ReserveToken pool, uint256 tokenAmount)
         external
         payable
-        override
         validAddress(ReserveToken.unwrap(pool))
         greaterThanZero(tokenAmount)
         nonReentrant
@@ -708,7 +705,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         bytes32 s
     )
         external
-        override
         validAddress(provider)
         validAddress(ReserveToken.unwrap(pool))
         greaterThanZero(tokenAmount)
@@ -727,14 +723,14 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external override validAddress(ReserveToken.unwrap(pool)) greaterThanZero(tokenAmount) nonReentrant {
+    ) external validAddress(ReserveToken.unwrap(pool)) greaterThanZero(tokenAmount) nonReentrant {
         _depositBaseTokenForPermitted(msg.sender, pool, tokenAmount, deadline, v, r, s);
     }
 
     /**
      * @inheritdoc IBancorNetwork
      */
-    function withdraw(uint256 id) external override nonReentrant {
+    function withdraw(uint256 id) external nonReentrant {
         address provider = msg.sender;
         bytes32 contextId = _withdrawContextId(id, provider);
 
@@ -761,7 +757,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     )
         external
         payable
-        override
         nonReentrant
         validTokensForTrade(sourceToken, targetToken)
         greaterThanZero(sourceAmount)
@@ -785,7 +780,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         bytes32 s
     )
         external
-        override
         nonReentrant
         validTokensForTrade(sourceToken, targetToken)
         greaterThanZero(sourceAmount)

--- a/packages/v3/contracts/network/BancorVault.sol
+++ b/packages/v3/contracts/network/BancorVault.sol
@@ -77,33 +77,33 @@ contract BancorVault is IBancorVault, Upgradeable, PausableUpgradeable, Reentran
         _setupRole(ROLE_ASSET_MANAGER, msg.sender);
     }
 
-    receive() external payable override {}
+    receive() external payable {}
 
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IBancorVault
      */
-    function isPaused() external view override returns (bool) {
+    function isPaused() external view returns (bool) {
         return paused();
     }
 
     /**
      * @inheritdoc IBancorVault
      */
-    function pause() external override onlyAdmin {
+    function pause() external onlyAdmin {
         _pause();
     }
 
     /**
      * @inheritdoc IBancorVault
      */
-    function unpause() external override onlyAdmin {
+    function unpause() external onlyAdmin {
         _unpause();
     }
 
@@ -114,7 +114,7 @@ contract BancorVault is IBancorVault, Upgradeable, PausableUpgradeable, Reentran
         ReserveToken reserveToken,
         address payable target,
         uint256 amount
-    ) external override validAddress(target) nonReentrant whenNotPaused {
+    ) external validAddress(target) nonReentrant whenNotPaused {
         if (
             (reserveToken.toIERC20() == _networkToken && hasRole(ROLE_NETWORK_TOKEN_MANAGER, msg.sender)) ||
             hasRole(ROLE_ASSET_MANAGER, msg.sender)

--- a/packages/v3/contracts/network/NetworkSettings.sol
+++ b/packages/v3/contracts/network/NetworkSettings.sol
@@ -116,14 +116,14 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc INetworkSettings
      */
-    function protectedTokenWhitelist() external view override returns (ReserveToken[] memory) {
+    function protectedTokenWhitelist() external view returns (ReserveToken[] memory) {
         uint256 length = _protectedTokenWhitelist.length();
         ReserveToken[] memory list = new ReserveToken[](length);
         for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
@@ -169,14 +169,14 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function isTokenWhitelisted(ReserveToken token) external view override returns (bool) {
+    function isTokenWhitelisted(ReserveToken token) external view returns (bool) {
         return _protectedTokenWhitelist.contains(ReserveToken.unwrap(token));
     }
 
     /**
      * @inheritdoc INetworkSettings
      */
-    function poolMintingLimit(ReserveToken pool) external view override returns (uint256) {
+    function poolMintingLimit(ReserveToken pool) external view returns (uint256) {
         return _poolMintingLimits[pool];
     }
 
@@ -205,7 +205,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function minLiquidityForTrading() external view override returns (uint256) {
+    function minLiquidityForTrading() external view returns (uint256) {
         return _minLiquidityForTrading;
     }
 
@@ -230,21 +230,21 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function networkFeeParams() external view override returns (ITokenHolder, uint32) {
+    function networkFeeParams() external view returns (ITokenHolder, uint32) {
         return (_networkFeeWallet, _networkFeePPM);
     }
 
     /**
      * @inheritdoc INetworkSettings
      */
-    function networkFeeWallet() external view override returns (ITokenHolder) {
+    function networkFeeWallet() external view returns (ITokenHolder) {
         return _networkFeeWallet;
     }
 
     /**
      * @inheritdoc INetworkSettings
      */
-    function networkFeePPM() external view override returns (uint32) {
+    function networkFeePPM() external view returns (uint32) {
         return _networkFeePPM;
     }
 
@@ -291,7 +291,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function withdrawalFeePPM() external view override returns (uint32) {
+    function withdrawalFeePPM() external view returns (uint32) {
         return _withdrawalFeePPM;
     }
 
@@ -316,7 +316,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function flashLoanFeePPM() external view override returns (uint32) {
+    function flashLoanFeePPM() external view returns (uint32) {
         return _flashLoanFeePPM;
     }
 
@@ -341,7 +341,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
     /**
      * @inheritdoc INetworkSettings
      */
-    function averageRateMaxDeviationPPM() external view override returns (uint32) {
+    function averageRateMaxDeviationPPM() external view returns (uint32) {
         return _averageRateMaxDeviationPPM;
     }
 

--- a/packages/v3/contracts/network/PendingWithdrawals.sol
+++ b/packages/v3/contracts/network/PendingWithdrawals.sol
@@ -144,21 +144,21 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function network() external view override returns (IBancorNetwork) {
+    function network() external view returns (IBancorNetwork) {
         return _network;
     }
 
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function lockDuration() external view override returns (uint32) {
+    function lockDuration() external view returns (uint32) {
         return _lockDuration;
     }
 
@@ -180,7 +180,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function withdrawalWindowDuration() external view override returns (uint32) {
+    function withdrawalWindowDuration() external view returns (uint32) {
         return _withdrawalWindowDuration;
     }
 
@@ -202,14 +202,14 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function withdrawalRequestCount(address provider) external view override returns (uint256) {
+    function withdrawalRequestCount(address provider) external view returns (uint256) {
         return _withdrawalRequestIdsByProvider[provider].length();
     }
 
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function withdrawalRequestIds(address provider) external view override returns (uint256[] memory) {
+    function withdrawalRequestIds(address provider) external view returns (uint256[] memory) {
         EnumerableSetUpgradeable.UintSet storage providerRequests = _withdrawalRequestIdsByProvider[provider];
         uint256 length = providerRequests.length();
         uint256[] memory list = new uint256[](length);
@@ -222,7 +222,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function withdrawalRequest(uint256 id) external view override returns (WithdrawalRequest memory) {
+    function withdrawalRequest(uint256 id) external view returns (WithdrawalRequest memory) {
         return _withdrawalRequests[id];
     }
 
@@ -231,7 +231,6 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
      */
     function initWithdrawal(IPoolToken poolToken, uint256 poolTokenAmount)
         external
-        override
         validAddress(address(poolToken))
         greaterThanZero(poolTokenAmount)
         nonReentrant
@@ -249,7 +248,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external override validAddress(address(poolToken)) greaterThanZero(poolTokenAmount) nonReentrant {
+    ) external validAddress(address(poolToken)) greaterThanZero(poolTokenAmount) nonReentrant {
         poolToken.permit(msg.sender, address(this), poolTokenAmount, deadline, v, r, s);
 
         _initWithdrawal(msg.sender, poolToken, poolTokenAmount);
@@ -258,7 +257,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function cancelWithdrawal(uint256 id) external override nonReentrant {
+    function cancelWithdrawal(uint256 id) external nonReentrant {
         WithdrawalRequest memory request = _withdrawalRequests[id];
         address provider = request.provider;
         if (provider != msg.sender) {
@@ -271,7 +270,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function reinitWithdrawal(uint256 id) external override nonReentrant {
+    function reinitWithdrawal(uint256 id) external nonReentrant {
         WithdrawalRequest storage request = _withdrawalRequests[id];
         address provider = request.provider;
         if (provider != msg.sender) {
@@ -298,7 +297,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
         bytes32 contextId,
         address provider,
         uint256 id
-    ) external override only(address(_network)) returns (CompletedWithdrawal memory) {
+    ) external only(address(_network)) returns (CompletedWithdrawal memory) {
         WithdrawalRequest memory request = _withdrawalRequests[id];
 
         if (provider != request.provider) {

--- a/packages/v3/contracts/pools/NetworkTokenPool.sol
+++ b/packages/v3/contracts/pools/NetworkTokenPool.sol
@@ -134,89 +134,84 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function network() external view override returns (IBancorNetwork) {
+    function network() external view returns (IBancorNetwork) {
         return _network;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function networkToken() external view override returns (IERC20) {
+    function networkToken() external view returns (IERC20) {
         return _networkToken;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function networkTokenGovernance() external view override returns (ITokenGovernance) {
+    function networkTokenGovernance() external view returns (ITokenGovernance) {
         return _networkTokenGovernance;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function govToken() external view override returns (IERC20) {
+    function govToken() external view returns (IERC20) {
         return _govToken;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function govTokenGovernance() external view override returns (ITokenGovernance) {
+    function govTokenGovernance() external view returns (ITokenGovernance) {
         return _govTokenGovernance;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function settings() external view override returns (INetworkSettings) {
+    function settings() external view returns (INetworkSettings) {
         return _settings;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function vault() external view override returns (IBancorVault) {
+    function vault() external view returns (IBancorVault) {
         return _vault;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function poolToken() external view override returns (IPoolToken) {
+    function poolToken() external view returns (IPoolToken) {
         return _poolToken;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function stakedBalance() external view override returns (uint256) {
+    function stakedBalance() external view returns (uint256) {
         return _stakedBalance;
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function mintedAmount(ReserveToken pool) external view override returns (uint256) {
+    function mintedAmount(ReserveToken pool) external view returns (uint256) {
         return _mintedAmounts[pool];
     }
 
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function isNetworkLiquidityEnabled(ReserveToken pool, IPoolCollection poolCollection)
-        external
-        view
-        override
-        returns (bool)
-    {
+    function isNetworkLiquidityEnabled(ReserveToken pool, IPoolCollection poolCollection) external view returns (bool) {
         return
             ReserveToken.unwrap(pool) != address(0) &&
             address(poolCollection) != address(0) &&
@@ -227,7 +222,7 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
     /**
      * @inheritdoc INetworkTokenPool
      */
-    function unallocatedLiquidity(ReserveToken pool) external view override returns (uint256) {
+    function unallocatedLiquidity(ReserveToken pool) external view returns (uint256) {
         return MathEx.subMax0(_settings.poolMintingLimit(pool), _mintedAmounts[pool]);
     }
 
@@ -236,7 +231,6 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
      */
     function mint(address recipient, uint256 networkTokenAmount)
         external
-        override
         only(address(_network))
         validAddress(recipient)
         greaterThanZero(networkTokenAmount)
@@ -249,7 +243,6 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
      */
     function burnFromVault(uint256 networkTokenAmount)
         external
-        override
         only(address(_network))
         greaterThanZero(networkTokenAmount)
     {
@@ -268,7 +261,6 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
         uint256 originalGovTokenAmount
     )
         external
-        override
         only(address(_network))
         validAddress(provider)
         greaterThanZero(networkTokenAmount)
@@ -308,7 +300,6 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
      */
     function withdraw(address provider, uint256 poolTokenAmount)
         external
-        override
         only(address(_network))
         greaterThanZero(poolTokenAmount)
         validAddress(provider)
@@ -341,13 +332,7 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
         bytes32 contextId,
         ReserveToken pool,
         uint256 networkTokenAmount
-    )
-        external
-        override
-        only(address(_network))
-        validAddress(ReserveToken.unwrap(pool))
-        greaterThanZero(networkTokenAmount)
-    {
+    ) external only(address(_network)) validAddress(ReserveToken.unwrap(pool)) greaterThanZero(networkTokenAmount) {
         uint256 currentMintedAmount = _mintedAmounts[pool];
         uint256 mintingLimit = _settings.poolMintingLimit(pool);
         uint256 newMintedAmount = currentMintedAmount + networkTokenAmount;
@@ -399,13 +384,7 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
         bytes32 contextId,
         ReserveToken pool,
         uint256 networkTokenAmount
-    )
-        external
-        override
-        only(address(_network))
-        validAddress(ReserveToken.unwrap(pool))
-        greaterThanZero(networkTokenAmount)
-    {
+    ) external only(address(_network)) validAddress(ReserveToken.unwrap(pool)) greaterThanZero(networkTokenAmount) {
         uint256 currentStakedBalance = _stakedBalance;
 
         // calculate the renounced amount to deduct from both the staked balance and pool minted amount
@@ -446,7 +425,7 @@ contract NetworkTokenPool is INetworkTokenPool, Upgradeable, ReentrancyGuardUpgr
         ReserveToken pool,
         uint256 networkTokenAmount,
         uint8 feeType
-    ) external override only(address(_network)) validAddress(ReserveToken.unwrap(pool)) {
+    ) external only(address(_network)) validAddress(ReserveToken.unwrap(pool)) {
         if (networkTokenAmount == 0) {
             return;
         }

--- a/packages/v3/contracts/pools/PoolCollection.sol
+++ b/packages/v3/contracts/pools/PoolCollection.sol
@@ -218,63 +218,63 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     /**
      * @dev returns the current version of the contract
      */
-    function version() external view virtual override returns (uint16) {
+    function version() external view virtual returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function poolType() external pure override returns (uint16) {
+    function poolType() external pure returns (uint16) {
         return POOL_TYPE;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function network() external view override returns (IBancorNetwork) {
+    function network() external view returns (IBancorNetwork) {
         return _network;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function networkToken() external view override returns (IERC20) {
+    function networkToken() external view returns (IERC20) {
         return _networkToken;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function settings() external view override returns (INetworkSettings) {
+    function settings() external view returns (INetworkSettings) {
         return _settings;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function poolTokenFactory() external view override returns (IPoolTokenFactory) {
+    function poolTokenFactory() external view returns (IPoolTokenFactory) {
         return _poolTokenFactory;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function poolCollectionUpgrader() external view override returns (IPoolCollectionUpgrader) {
+    function poolCollectionUpgrader() external view returns (IPoolCollectionUpgrader) {
         return _poolCollectionUpgrader;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function defaultTradingFeePPM() external view override returns (uint32) {
+    function defaultTradingFeePPM() external view returns (uint32) {
         return _defaultTradingFeePPM;
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function pools() external view override returns (ReserveToken[] memory) {
+    function pools() external view returns (ReserveToken[] memory) {
         uint256 length = _pools.length();
         ReserveToken[] memory list = new ReserveToken[](length);
         for (uint256 i = 0; i < length; i = uncheckedInc(i)) {
@@ -286,7 +286,7 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     /**
      * @inheritdoc IPoolCollection
      */
-    function poolCount() external view override returns (uint256) {
+    function poolCount() external view returns (uint256) {
         return _pools.length();
     }
 
@@ -308,7 +308,7 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     /**
      * @inheritdoc IPoolCollection
      */
-    function createPool(ReserveToken reserveToken) external override only(address(_network)) nonReentrant {
+    function createPool(ReserveToken reserveToken) external only(address(_network)) nonReentrant {
         if (!_settings.isTokenWhitelisted(reserveToken)) {
             revert NotWhitelisted();
         }
@@ -354,14 +354,14 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     /**
      * @inheritdoc IPoolCollection
      */
-    function isPoolValid(ReserveToken reserveToken) external view override returns (bool) {
+    function isPoolValid(ReserveToken reserveToken) external view returns (bool) {
         return _validPool(_poolData[reserveToken]);
     }
 
     /**
      * @inheritdoc IPoolCollection
      */
-    function isPoolRateStable(ReserveToken reserveToken) external view override returns (bool) {
+    function isPoolRateStable(ReserveToken reserveToken) external view returns (bool) {
         Pool memory data = _poolData[reserveToken];
         if (!_validPool(data)) {
             return false;
@@ -389,7 +389,7 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     /**
      * @inheritdoc IPoolCollection
      */
-    function poolLiquidity(ReserveToken reserveToken) external view override returns (PoolLiquidity memory) {
+    function poolLiquidity(ReserveToken reserveToken) external view returns (PoolLiquidity memory) {
         return _poolData[reserveToken].liquidity;
     }
 
@@ -509,7 +509,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
         uint256 unallocatedNetworkTokenLiquidity
     )
         external
-        override
         only(address(_network))
         validAddress(provider)
         validAddress(ReserveToken.unwrap(pool))
@@ -586,7 +585,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
         uint256 externalProtectionWalletBalance
     )
         external
-        override
         only(address(_network))
         validAddress(ReserveToken.unwrap(pool))
         greaterThanZero(basePoolTokenAmount)
@@ -620,7 +618,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
         uint256 minReturnAmount
     )
         external
-        override
         only(address(_network))
         validAddress(ReserveToken.unwrap(sourceToken))
         validAddress(ReserveToken.unwrap(targetToken))
@@ -702,7 +699,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
     )
         external
         view
-        override
         validAddress(ReserveToken.unwrap(sourceToken))
         validAddress(ReserveToken.unwrap(targetToken))
         greaterThanZero(amount)
@@ -721,7 +717,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
      */
     function onFeesCollected(ReserveToken pool, uint256 baseTokenAmount)
         external
-        override
         only(address(_network))
         validAddress(ReserveToken.unwrap(pool))
     {
@@ -740,7 +735,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
      */
     function migratePoolIn(ReserveToken pool, Pool calldata data)
         external
-        override
         validAddress(ReserveToken.unwrap(pool))
         only(address(_poolCollectionUpgrader))
     {
@@ -756,7 +750,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuardUpgradeable, T
      */
     function migratePoolOut(ReserveToken pool, IPoolCollection targetPoolCollection)
         external
-        override
         validAddress(ReserveToken.unwrap(pool))
         validAddress(address(targetPoolCollection))
         only(address(_poolCollectionUpgrader))

--- a/packages/v3/contracts/pools/PoolCollectionUpgrader.sol
+++ b/packages/v3/contracts/pools/PoolCollectionUpgrader.sol
@@ -102,14 +102,14 @@ contract PoolCollectionUpgrader is IPoolCollectionUpgrader, Upgradeable, Utils {
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IPoolCollectionUpgrader
      */
-    function network() external view override returns (IBancorNetwork) {
+    function network() external view returns (IBancorNetwork) {
         return _network;
     }
 

--- a/packages/v3/contracts/pools/PoolToken.sol
+++ b/packages/v3/contracts/pools/PoolToken.sol
@@ -36,7 +36,7 @@ contract PoolToken is IPoolToken, ERC20Permit, ERC20Burnable, Owned, Utils {
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
@@ -50,14 +50,14 @@ contract PoolToken is IPoolToken, ERC20Permit, ERC20Burnable, Owned, Utils {
     /**
      * @inheritdoc IPoolToken
      */
-    function reserveToken() external view override returns (ReserveToken) {
+    function reserveToken() external view returns (ReserveToken) {
         return _reserveToken;
     }
 
     /**
      * @inheritdoc IPoolToken
      */
-    function mint(address recipient, uint256 amount) external override onlyOwner validExternalAddress(recipient) {
+    function mint(address recipient, uint256 amount) external onlyOwner validExternalAddress(recipient) {
         _mint(recipient, amount);
     }
 }

--- a/packages/v3/contracts/pools/PoolTokenFactory.sol
+++ b/packages/v3/contracts/pools/PoolTokenFactory.sol
@@ -62,14 +62,14 @@ contract PoolTokenFactory is IPoolTokenFactory, Upgradeable, Utils {
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
     /**
      * @inheritdoc IPoolTokenFactory
      */
-    function tokenSymbolOverride(ReserveToken reserveToken) external view override returns (string memory) {
+    function tokenSymbolOverride(ReserveToken reserveToken) external view returns (string memory) {
         return _tokenSymbolOverrides[reserveToken];
     }
 
@@ -87,7 +87,7 @@ contract PoolTokenFactory is IPoolTokenFactory, Upgradeable, Utils {
     /**
      * @inheritdoc IPoolTokenFactory
      */
-    function tokenDecimalsOverride(ReserveToken reserveToken) external view override returns (uint8) {
+    function tokenDecimalsOverride(ReserveToken reserveToken) external view returns (uint8) {
         return _tokenDecimalsOverrides[reserveToken];
     }
 
@@ -107,7 +107,6 @@ contract PoolTokenFactory is IPoolTokenFactory, Upgradeable, Utils {
      */
     function createPoolToken(ReserveToken reserveToken)
         external
-        override
         validAddress(ReserveToken.unwrap(reserveToken))
         returns (IPoolToken)
     {

--- a/packages/v3/contracts/token/ERC20Burnable.sol
+++ b/packages/v3/contracts/token/ERC20Burnable.sol
@@ -17,14 +17,14 @@ abstract contract ERC20Burnable is ERC20, IERC20Burnable {
     /**
      * @inheritdoc IERC20Burnable
      */
-    function burn(uint256 amount) external virtual override {
+    function burn(uint256 amount) external virtual {
         _burn(msg.sender, amount);
     }
 
     /**
      * @inheritdoc IERC20Burnable
      */
-    function burnFrom(address recipient, uint256 amount) external virtual override {
+    function burnFrom(address recipient, uint256 amount) external virtual {
         uint256 currentAllowance = allowance(recipient, msg.sender);
         if (currentAllowance < amount) {
             revert InsufficientAllowance();

--- a/packages/v3/contracts/utility/Owned.sol
+++ b/packages/v3/contracts/utility/Owned.sol
@@ -46,14 +46,14 @@ abstract contract Owned is IOwned {
     /**
      * @inheritdoc IOwned
      */
-    function owner() public view virtual override returns (address) {
+    function owner() public view virtual returns (address) {
         return _owner;
     }
 
     /**
      * @inheritdoc IOwned
      */
-    function transferOwnership(address ownerCandidate) public virtual override onlyOwner {
+    function transferOwnership(address ownerCandidate) public virtual onlyOwner {
         if (ownerCandidate == _owner) {
             revert SameOwner();
         }
@@ -64,7 +64,7 @@ abstract contract Owned is IOwned {
     /**
      * @inheritdoc IOwned
      */
-    function acceptOwnership() public virtual override {
+    function acceptOwnership() public virtual {
         if (msg.sender != _newOwner) {
             revert AccessDenied();
         }

--- a/packages/v3/contracts/utility/TokenHolder.sol
+++ b/packages/v3/contracts/utility/TokenHolder.sol
@@ -18,12 +18,12 @@ error InvalidLength();
 contract TokenHolder is IVersioned, ITokenHolder, Owned, Utils {
     using ReserveTokenLibrary for ReserveToken;
 
-    receive() external payable virtual override {}
+    receive() external payable virtual {}
 
     /**
      * @dev returns the current version of the contract
      */
-    function version() external pure override returns (uint16) {
+    function version() external pure returns (uint16) {
         return 1;
     }
 
@@ -34,7 +34,7 @@ contract TokenHolder is IVersioned, ITokenHolder, Owned, Utils {
         ReserveToken reserveToken,
         address payable to,
         uint256 amount
-    ) external virtual override onlyOwner validAddress(to) {
+    ) external virtual onlyOwner validAddress(to) {
         reserveToken.safeTransfer(to, amount);
     }
 
@@ -45,7 +45,7 @@ contract TokenHolder is IVersioned, ITokenHolder, Owned, Utils {
         ReserveToken[] calldata reserveTokens,
         address payable to,
         uint256[] calldata amounts
-    ) external virtual override onlyOwner validAddress(to) {
+    ) external virtual onlyOwner validAddress(to) {
         uint256 length = reserveTokens.length;
         if (length != amounts.length) {
             revert InvalidLength();


### PR DESCRIPTION
…ride only a single interface function