### PR TITLE
Use OZ custom modifier `onlyRole`

### DIFF
--- a/packages/v3/contracts/helpers/TestUpgradeable.sol
+++ b/packages/v3/contracts/helpers/TestUpgradeable.sol
@@ -22,5 +22,5 @@ contract TestUpgradeable is Upgradeable {
         return 1;
     }
 
-    function restricted() external view onlyAdmin {}
+    function restricted() external view onlyRole(ROLE_ADMIN) {}
 }

--- a/packages/v3/contracts/network/BancorNetwork.sol
+++ b/packages/v3/contracts/network/BancorNetwork.sol
@@ -447,7 +447,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     function setExternalProtectionWallet(ITokenHolder newExternalProtectionWallet)
         external
         validAddress(address(newExternalProtectionWallet))
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
     {
         ITokenHolder prevExternalProtectionWallet = _externalProtectionWallet;
         if (prevExternalProtectionWallet == newExternalProtectionWallet) {
@@ -472,7 +472,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
      * - the caller must be the admin of the contract
      * - the new owner needs to accept the transfer
      */
-    function transferExternalProtectionWalletOwnership(address newOwner) external onlyAdmin {
+    function transferExternalProtectionWalletOwnership(address newOwner) external onlyRole(ROLE_ADMIN) {
         _externalProtectionWallet.transferOwnership(newOwner);
     }
 
@@ -487,7 +487,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         external
         validAddress(address(poolCollection))
         nonReentrant
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
     {
         if (!_poolCollections.add(address(poolCollection))) {
             revert AlreadyExists();
@@ -518,7 +518,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     function removePoolCollection(IPoolCollection poolCollection, IPoolCollection newLatestPoolCollection)
         external
         validAddress(address(poolCollection))
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
         nonReentrant
     {
         // verify that a pool collection is a valid latest pool collection (e.g., it either exists or a reset to zero)
@@ -557,7 +557,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         external
         nonReentrant
         validAddress(address(poolCollection))
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
     {
         _verifyLatestPoolCollectionCandidate(poolCollection);
 

--- a/packages/v3/contracts/network/BancorVault.sol
+++ b/packages/v3/contracts/network/BancorVault.sol
@@ -8,7 +8,7 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import { Upgradeable } from "../utility/Upgradeable.sol";
-import { Utils, AccessDenied } from "../utility/Utils.sol";
+import { Utils, AccessControl } from "../utility/Utils.sol";
 
 import { ReserveToken, ReserveTokenLibrary } from "../token/ReserveToken.sol";
 
@@ -96,14 +96,14 @@ contract BancorVault is IBancorVault, Upgradeable, PausableUpgradeable, Reentran
     /**
      * @inheritdoc IBancorVault
      */
-    function pause() external onlyAdmin {
+    function pause() external onlyRole(ROLE_ADMIN) {
         _pause();
     }
 
     /**
      * @inheritdoc IBancorVault
      */
-    function unpause() external onlyAdmin {
+    function unpause() external onlyRole(ROLE_ADMIN) {
         _unpause();
     }
 
@@ -123,7 +123,7 @@ contract BancorVault is IBancorVault, Upgradeable, PausableUpgradeable, Reentran
 
             emit TokensWithdrawn({ token: reserveToken, caller: msg.sender, target: target, amount: amount });
         } else {
-            revert AccessDenied();
+            revert AccessControl();
         }
     }
 }

--- a/packages/v3/contracts/network/NetworkSettings.sol
+++ b/packages/v3/contracts/network/NetworkSettings.sol
@@ -141,7 +141,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      */
     function addTokenToWhitelist(ReserveToken token)
         external
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
         validExternalAddress(ReserveToken.unwrap(token))
     {
         if (!_protectedTokenWhitelist.add(ReserveToken.unwrap(token))) {
@@ -158,7 +158,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function removeTokenFromWhitelist(ReserveToken token) external onlyAdmin {
+    function removeTokenFromWhitelist(ReserveToken token) external onlyRole(ROLE_ADMIN) {
         if (!_protectedTokenWhitelist.remove(ReserveToken.unwrap(token))) {
             revert DoesNotExist();
         }
@@ -189,7 +189,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      */
     function setPoolMintingLimit(ReserveToken pool, uint256 amount)
         external
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
         validAddress(ReserveToken.unwrap(pool))
     {
         uint256 prevPoolMintingLimit = _poolMintingLimits[pool];
@@ -216,7 +216,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setMinLiquidityForTrading(uint256 amount) external onlyAdmin {
+    function setMinLiquidityForTrading(uint256 amount) external onlyRole(ROLE_ADMIN) {
         uint256 prevMinLiquidityForTrading = _minLiquidityForTrading;
         if (_minLiquidityForTrading == amount) {
             return;
@@ -257,7 +257,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      */
     function setNetworkFeeWallet(ITokenHolder newNetworkFeeWallet)
         external
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
         validAddress(address(newNetworkFeeWallet))
     {
         ITokenHolder prevNetworkFeeWallet = _networkFeeWallet;
@@ -277,7 +277,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setNetworkFeePPM(uint32 newNetworkFeePPM) external onlyAdmin validFee(newNetworkFeePPM) {
+    function setNetworkFeePPM(uint32 newNetworkFeePPM) external onlyRole(ROLE_ADMIN) validFee(newNetworkFeePPM) {
         uint32 prevNetworkFeePPM = _networkFeePPM;
         if (prevNetworkFeePPM == newNetworkFeePPM) {
             return;
@@ -302,7 +302,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setWithdrawalFeePPM(uint32 newWithdrawalFeePPM) external onlyAdmin validFee(newWithdrawalFeePPM) {
+    function setWithdrawalFeePPM(uint32 newWithdrawalFeePPM) external onlyRole(ROLE_ADMIN) validFee(newWithdrawalFeePPM) {
         uint32 prevWithdrawalFeePPM = _withdrawalFeePPM;
         if (prevWithdrawalFeePPM == newWithdrawalFeePPM) {
             return;
@@ -327,7 +327,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setFlashLoanFeePPM(uint32 newFlashLoanFeePPM) external onlyAdmin validFee(newFlashLoanFeePPM) {
+    function setFlashLoanFeePPM(uint32 newFlashLoanFeePPM) external onlyRole(ROLE_ADMIN) validFee(newFlashLoanFeePPM) {
         uint32 prevFlashLoanFeePPM = _flashLoanFeePPM;
         if (prevFlashLoanFeePPM == newFlashLoanFeePPM) {
             return;
@@ -354,7 +354,7 @@ contract NetworkSettings is INetworkSettings, Upgradeable, Utils {
      */
     function setAverageRateMaxDeviationPPM(uint32 newAverageRateMaxDeviationPPM)
         external
-        onlyAdmin
+        onlyRole(ROLE_ADMIN)
         validPortion(newAverageRateMaxDeviationPPM)
     {
         uint32 prevAverageRateMaxDeviationPPM = _averageRateMaxDeviationPPM;

--- a/packages/v3/contracts/network/PendingWithdrawals.sol
+++ b/packages/v3/contracts/network/PendingWithdrawals.sol
@@ -10,7 +10,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ReserveToken } from "../token/ReserveToken.sol";
 
 import { Upgradeable } from "../utility/Upgradeable.sol";
-import { Utils, AccessDenied, AlreadyExists, DoesNotExist, InvalidPool } from "../utility/Utils.sol";
+import { Utils, AccessControl, AlreadyExists, DoesNotExist, InvalidPool } from "../utility/Utils.sol";
 import { Time } from "../utility/Time.sol";
 import { uncheckedInc } from "../utility/MathEx.sol";
 
@@ -173,7 +173,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
      *
      * - the caller must be the admin of the contract
      */
-    function setLockDuration(uint32 newLockDuration) external onlyAdmin {
+    function setLockDuration(uint32 newLockDuration) external onlyRole(ROLE_ADMIN) {
         _setLockDuration(newLockDuration);
     }
 
@@ -195,7 +195,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
      *
      * - the caller must be the admin of the contract
      */
-    function setWithdrawalWindowDuration(uint32 newWithdrawalWindowDuration) external onlyAdmin {
+    function setWithdrawalWindowDuration(uint32 newWithdrawalWindowDuration) external onlyRole(ROLE_ADMIN) {
         _setWithdrawalWindowDuration(newWithdrawalWindowDuration);
     }
 
@@ -270,7 +270,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
         WithdrawalRequest memory request = _withdrawalRequests[id];
         address provider = request.provider;
         if (provider != msg.sender) {
-            revert AccessDenied();
+            revert AccessControl();
         }
 
         _cancelWithdrawal(request, id);
@@ -283,7 +283,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
         WithdrawalRequest storage request = _withdrawalRequests[id];
         address provider = request.provider;
         if (provider != msg.sender) {
-            revert AccessDenied();
+            revert AccessControl();
         }
 
         uint32 currentTime = _time();
@@ -310,7 +310,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, ReentrancyGuard
         WithdrawalRequest memory request = _withdrawalRequests[id];
 
         if (provider != request.provider) {
-            revert AccessDenied();
+            revert AccessControl();
         }
 
         uint32 currentTime = _time();

--- a/packages/v3/contracts/pools/PoolTokenFactory.sol
+++ b/packages/v3/contracts/pools/PoolTokenFactory.sol
@@ -80,7 +80,7 @@ contract PoolTokenFactory is IPoolTokenFactory, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setTokenSymbolOverride(ReserveToken reserveToken, string calldata symbol) external onlyAdmin {
+    function setTokenSymbolOverride(ReserveToken reserveToken, string calldata symbol) external onlyRole(ROLE_ADMIN) {
         _tokenSymbolOverrides[reserveToken] = symbol;
     }
 
@@ -98,7 +98,7 @@ contract PoolTokenFactory is IPoolTokenFactory, Upgradeable, Utils {
      *
      * - the caller must be the admin of the contract
      */
-    function setTokenDecimalsOverride(ReserveToken reserveToken, uint8 decimals) external onlyAdmin {
+    function setTokenDecimalsOverride(ReserveToken reserveToken, uint8 decimals) external onlyRole(ROLE_ADMIN) {
         _tokenDecimalsOverrides[reserveToken] = decimals;
     }
 

--- a/packages/v3/contracts/utility/Owned.sol
+++ b/packages/v3/contracts/utility/Owned.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import { IOwned } from "./interfaces/IOwned.sol";
-import { AccessDenied } from "./Utils.sol";
+import { AccessControl } from "./Utils.sol";
 
 error SameOwner();
 
@@ -39,7 +39,7 @@ abstract contract Owned is IOwned {
     // error message binary size optimization
     function _onlyOwner() private view {
         if (msg.sender != _owner) {
-            revert AccessDenied();
+            revert AccessControl();
         }
     }
 
@@ -66,7 +66,7 @@ abstract contract Owned is IOwned {
      */
     function acceptOwnership() public virtual {
         if (msg.sender != _newOwner) {
-            revert AccessDenied();
+            revert AccessControl();
         }
 
         _setOwner(_newOwner);

--- a/packages/v3/contracts/utility/Upgradeable.sol
+++ b/packages/v3/contracts/utility/Upgradeable.sol
@@ -6,7 +6,7 @@ import { AccessControlEnumerableUpgradeable } from "@openzeppelin/contracts-upgr
 
 import { IUpgradeable } from "./interfaces/IUpgradeable.sol";
 
-import { AccessDenied } from "./Utils.sol";
+import { AccessControl } from "./Utils.sol";
 
 /**
  * @dev this contract provides common utilities for upgradeable contracts
@@ -37,19 +37,5 @@ abstract contract Upgradeable is IUpgradeable, Initializable, AccessControlEnume
 
         // allow the deployer to initially be the admin of the contract
         _setupRole(ROLE_ADMIN, msg.sender);
-    }
-
-    // solhint-enable func-name-mixedcase
-
-    modifier onlyAdmin() {
-        _hasRole(ROLE_ADMIN, msg.sender);
-
-        _;
-    }
-
-    function _hasRole(bytes32 role, address account) internal view {
-        if (!hasRole(role, account)) {
-            revert AccessDenied();
-        }
     }
 }

--- a/packages/v3/contracts/utility/Utils.sol
+++ b/packages/v3/contracts/utility/Utils.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import { PPM_RESOLUTION } from "./Constants.sol";
 
-error AccessDenied();
+error AccessControl();
 error AlreadyExists();
 error DoesNotExist();
 error InvalidAddress();
@@ -33,7 +33,7 @@ contract Utils {
 
     function _only(address sender) internal view {
         if (msg.sender != sender) {
-            revert AccessDenied();
+            revert AccessControl();
         }
     }
 

--- a/packages/v3/test/network/BancorNetwork.ts
+++ b/packages/v3/test/network/BancorNetwork.ts
@@ -391,7 +391,7 @@ describe('BancorNetwork', () => {
         it('should revert when a non-owner attempts to set the external protection wallet', async () => {
             await expect(
                 network.connect(nonOwner).setExternalProtectionWallet(newExternalProtectionWallet.address)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when setting external protection wallet to an invalid address', async () => {
@@ -429,14 +429,14 @@ describe('BancorNetwork', () => {
 
         it('should revert when attempting to set the external protection wallet without transferring its ownership', async () => {
             await expect(network.setExternalProtectionWallet(newExternalProtectionWallet.address)).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
         it('should revert when a non-owner attempts to transfer the ownership of the protection wallet', async () => {
             await expect(
                 network.connect(newOwner).transferExternalProtectionWalletOwnership(newOwner.address)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should allow explicitly transferring the ownership', async () => {
@@ -468,7 +468,7 @@ describe('BancorNetwork', () => {
         describe('adding new pool collection', () => {
             it('should revert when a non-owner attempts to add a new pool collection', async () => {
                 await expect(network.connect(nonOwner).addPoolCollection(poolCollection.address)).to.be.revertedWith(
-                    'AccessDenied'
+                    'AccessControl'
                 );
             });
 
@@ -608,7 +608,7 @@ describe('BancorNetwork', () => {
                         network
                             .connect(nonOwner)
                             .removePoolCollection(poolCollection.address, newPoolCollection.address)
-                    ).to.be.revertedWith('AccessDenied');
+                    ).to.be.revertedWith('AccessControl');
                 });
 
                 it('should revert when attempting to remove a non-existing pool collection', async () => {
@@ -702,7 +702,7 @@ describe('BancorNetwork', () => {
             it('should revert when a non-owner attempts to set the latest pool collection', async () => {
                 await expect(
                     network.connect(nonOwner).setLatestPoolCollection(poolCollection.address)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when attempting to set the latest pool collection to an invalid pool collection', async () => {
@@ -1818,7 +1818,7 @@ describe('BancorNetwork', () => {
         });
 
         it('should revert when attempting to withdraw a non-existing withdrawal request', async () => {
-            await expect(network.withdraw(BigNumber.from(12345))).to.be.revertedWith('AccessDenied');
+            await expect(network.withdraw(BigNumber.from(12345))).to.be.revertedWith('AccessControl');
         });
 
         const testWithdraw = async (symbol: string) => {
@@ -1877,7 +1877,7 @@ describe('BancorNetwork', () => {
                 });
 
                 it('should revert when attempting to withdraw from a different provider', async () => {
-                    await expect(network.connect(deployer).withdraw(id)).to.be.revertedWith('AccessDenied');
+                    await expect(network.connect(deployer).withdraw(id)).to.be.revertedWith('AccessControl');
                 });
 
                 context('during the lock duration', () => {

--- a/packages/v3/test/network/BancorVault.ts
+++ b/packages/v3/test/network/BancorVault.ts
@@ -138,7 +138,7 @@ describe('BancorVault', () => {
                     });
                 };
 
-                const testWithdrawRestricted = (reason = 'AccessDenied') => {
+                const testWithdrawRestricted = (reason = 'AccessControl') => {
                     it('should not be able to withdraw any tokens', async () => {
                         await expect(
                             bancorVault.connect(sender).withdrawTokens(token.address, target.address, amount)
@@ -244,7 +244,7 @@ describe('BancorVault', () => {
 
         const testPauseRestricted = () => {
             it('should revert when a non-admin is attempting to pause', async () => {
-                await expect(bancorVault.connect(sender).pause()).to.be.revertedWith('AccessDenied');
+                await expect(bancorVault.connect(sender).pause()).to.be.revertedWith('AccessControl');
             });
 
             context('when paused', () => {
@@ -256,7 +256,7 @@ describe('BancorVault', () => {
                 });
 
                 it('should revert when a non-admin is attempting unpause', async () => {
-                    await expect(bancorVault.connect(sender).unpause()).to.be.revertedWith('AccessDenied');
+                    await expect(bancorVault.connect(sender).unpause()).to.be.revertedWith('AccessControl');
                 });
             });
         };

--- a/packages/v3/test/network/NetworkSettings.ts
+++ b/packages/v3/test/network/NetworkSettings.ts
@@ -76,7 +76,7 @@ describe('NetworkSettings', () => {
             it('should revert when a non-owner attempts to add a token', async () => {
                 await expect(
                     networkSettings.connect(nonOwner).addTokenToWhitelist(reserveToken.address)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when adding an invalid address', async () => {
@@ -110,7 +110,7 @@ describe('NetworkSettings', () => {
             it('should revert when a non-owner attempts to remove a token', async () => {
                 await expect(
                     networkSettings.connect(nonOwner).removeTokenFromWhitelist(reserveToken.address)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when removing a non-whitelisted token', async () => {
@@ -144,7 +144,7 @@ describe('NetworkSettings', () => {
         it('should revert when a non-owner attempts to set a pool limit', async () => {
             await expect(
                 networkSettings.connect(nonOwner).setPoolMintingLimit(reserveToken.address, poolMintingLimit)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when setting a pool limit of an invalid address token', async () => {
@@ -190,7 +190,7 @@ describe('NetworkSettings', () => {
         it('should revert when a non-owner attempts to set the minimum liquidity for trading', async () => {
             await expect(
                 networkSettings.connect(nonOwner).setMinLiquidityForTrading(minLiquidityForTrading)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should ignore setting to the same minimum liquidity for trading', async () => {
@@ -245,9 +245,9 @@ describe('NetworkSettings', () => {
         it('should revert when a non-owner attempts to set the network fee params', async () => {
             await expect(
                 networkSettings.connect(nonOwner).setNetworkFeeWallet(newNetworkFeeWallet.address)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
             await expect(networkSettings.connect(nonOwner).setNetworkFeePPM(newNetworkFee)).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
@@ -315,7 +315,7 @@ describe('NetworkSettings', () => {
 
         it('should revert when a non-owner attempts to set the withdrawal fee', async () => {
             await expect(networkSettings.connect(nonOwner).setWithdrawalFeePPM(newWithdrawalFee)).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
@@ -361,7 +361,7 @@ describe('NetworkSettings', () => {
 
         it('should revert when a non-owner attempts to set the flash-loan fee', async () => {
             await expect(networkSettings.connect(nonOwner).setFlashLoanFeePPM(newFlashLoanFee)).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
@@ -408,7 +408,7 @@ describe('NetworkSettings', () => {
         it('should revert when a non-owner attempts to set the maximum deviation', async () => {
             await expect(
                 networkSettings.connect(nonOwner).setAverageRateMaxDeviationPPM(newMaxDeviation)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when setting the maximum deviation to an invalid value', async () => {

--- a/packages/v3/test/network/PendingWithdrawals.ts
+++ b/packages/v3/test/network/PendingWithdrawals.ts
@@ -89,7 +89,7 @@ describe('PendingWithdrawals', () => {
 
         it('should revert when a non-owner attempts to set the lock duration', async () => {
             await expect(pendingWithdrawals.connect(nonOwner).setLockDuration(newLockDuration)).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
@@ -130,7 +130,7 @@ describe('PendingWithdrawals', () => {
         it('should revert when a non-owner attempts to set the withdrawal window duration', async () => {
             await expect(
                 pendingWithdrawals.connect(nonOwner).setWithdrawalWindowDuration(newWithdrawalWindowDuration)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should ignore updating to the same withdrawal window duration', async () => {
@@ -393,7 +393,7 @@ describe('PendingWithdrawals', () => {
 
                 it('should revert when cancelling a non-existing withdrawal request', async () => {
                     await expect(pendingWithdrawals.cancelWithdrawal(BigNumber.from(1))).to.be.revertedWith(
-                        'AccessDenied'
+                        'AccessControl'
                     );
                 });
 
@@ -462,13 +462,13 @@ describe('PendingWithdrawals', () => {
 
                         await expect(
                             pendingWithdrawals.connect(provider1).cancelWithdrawal(provider2Id)
-                        ).to.be.revertedWith('AccessDenied');
+                        ).to.be.revertedWith('AccessControl');
                     });
 
                     it('should revert when cancelling a withdrawal request twice', async () => {
                         await pendingWithdrawals.connect(provider1).cancelWithdrawal(id1);
                         await expect(pendingWithdrawals.connect(provider1).cancelWithdrawal(id1)).to.be.revertedWith(
-                            'AccessDenied'
+                            'AccessControl'
                         );
                     });
 
@@ -505,7 +505,7 @@ describe('PendingWithdrawals', () => {
 
                 it('should revert when attempting to reinitiate a non-existing withdrawal request', async () => {
                     await expect(pendingWithdrawals.reinitWithdrawal(BigNumber.from(1))).to.be.revertedWith(
-                        'AccessDenied'
+                        'AccessControl'
                     );
                 });
 
@@ -578,7 +578,7 @@ describe('PendingWithdrawals', () => {
 
                         await expect(
                             pendingWithdrawals.connect(provider1).reinitWithdrawal(provider2Id)
-                        ).to.be.revertedWith('AccessDenied');
+                        ).to.be.revertedWith('AccessControl');
                     });
 
                     it('should reinitiate withdrawal requests', async () => {
@@ -614,7 +614,7 @@ describe('PendingWithdrawals', () => {
                 it('should revert when attempting to complete a non-existing withdrawal request', async () => {
                     await expect(
                         pendingWithdrawals.completeWithdrawal(contextId, provider.address, BigNumber.from(100))
-                    ).to.be.revertedWith('AccessDenied');
+                    ).to.be.revertedWith('AccessControl');
                 });
 
                 context('with an initiated withdrawal request', () => {
@@ -683,7 +683,7 @@ describe('PendingWithdrawals', () => {
 
                         await expect(
                             pendingWithdrawals.connect(nonNetwork).completeWithdrawal(contextId, provider.address, id)
-                        ).to.be.revertedWith('AccessDenied');
+                        ).to.be.revertedWith('AccessControl');
                     });
 
                     context('during the lock duration', () => {
@@ -738,7 +738,7 @@ describe('PendingWithdrawals', () => {
                             await network.completeWithdrawalT(contextId, provider.address, id);
 
                             await expect(pendingWithdrawals.connect(provider).cancelWithdrawal(id)).to.be.revertedWith(
-                                'AccessDenied'
+                                'AccessControl'
                             );
                         });
                     });

--- a/packages/v3/test/pools/NetworkTokenPool.ts
+++ b/packages/v3/test/pools/NetworkTokenPool.ts
@@ -118,7 +118,7 @@ describe('NetworkTokenPool', () => {
 
             await expect(
                 networkTokenPool.connect(nonNetwork).mint(recipient.address, BigNumber.from(1))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to mint to an invalid address', async () => {
@@ -160,7 +160,7 @@ describe('NetworkTokenPool', () => {
             const nonNetwork = deployer;
 
             await expect(networkTokenPool.connect(nonNetwork).burnFromVault(BigNumber.from(1))).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
 
@@ -389,7 +389,7 @@ describe('NetworkTokenPool', () => {
                 networkTokenPool
                     .connect(nonNetwork)
                     .requestLiquidity(contextId, reserveToken.address, BigNumber.from(1))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to request liquidity for an invalid pool', async () => {
@@ -529,7 +529,7 @@ describe('NetworkTokenPool', () => {
                 networkTokenPool
                     .connect(nonNetwork)
                     .renounceLiquidity(contextId, reserveToken.address, BigNumber.from(1))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to renounce liquidity for an invalid pool', async () => {
@@ -647,7 +647,7 @@ describe('NetworkTokenPool', () => {
 
             await expect(
                 networkTokenPool.connect(nonNetwork).depositFor(provider.address, amount, false, BigNumber.from(0))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to deposit a zero amount', async () => {
@@ -836,7 +836,7 @@ describe('NetworkTokenPool', () => {
 
             await expect(
                 networkTokenPool.connect(nonNetwork).withdraw(provider.address, BigNumber.from(1))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to withdraw for an invalid provider', async () => {
@@ -1040,7 +1040,7 @@ describe('NetworkTokenPool', () => {
                 networkTokenPool
                     .connect(nonNetwork)
                     .onFeesCollected(reserveToken.address, BigNumber.from(1), FeeTypes.Trading)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to notify about collected fee from an invalid pool', async () => {

--- a/packages/v3/test/pools/PoolCollection.ts
+++ b/packages/v3/test/pools/PoolCollection.ts
@@ -117,7 +117,7 @@ describe('PoolCollection', () => {
         it('should revert when a non-owner attempts to set the default trading fee', async () => {
             await expect(
                 poolCollection.connect(nonOwner).setDefaultTradingFeePPM(newDefaultTradingFree)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when setting the default trading fee to an invalid value', async () => {
@@ -166,7 +166,7 @@ describe('PoolCollection', () => {
                 const nonNetwork = deployer;
 
                 await expect(poolCollection.connect(nonNetwork).createPool(reserveToken.address)).to.be.revertedWith(
-                    'AccessDenied'
+                    'AccessControl'
                 );
             });
 
@@ -278,7 +278,7 @@ describe('PoolCollection', () => {
             it('should revert when a non-owner attempts to set the initial rate', async () => {
                 await expect(
                     poolCollection.connect(nonOwner).setInitialRate(reserveToken.address, newInitialRate)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when setting an invalid rate', async () => {
@@ -342,7 +342,7 @@ describe('PoolCollection', () => {
             it('should revert when a non-owner attempts to set the trading fee', async () => {
                 await expect(
                     poolCollection.connect(nonOwner).setTradingFeePPM(reserveToken.address, newTradingFee)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when setting an invalid trading fee', async () => {
@@ -394,7 +394,7 @@ describe('PoolCollection', () => {
             it('should revert when a non-owner attempts to enable trading', async () => {
                 await expect(
                     poolCollection.connect(nonOwner).enableTrading(reserveToken.address, true)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when enabling trading for a non-existing pool', async () => {
@@ -439,7 +439,7 @@ describe('PoolCollection', () => {
             it('should revert when a non-owner attempts to enable depositing', async () => {
                 await expect(
                     poolCollection.connect(nonOwner).enableDepositing(reserveToken.address, true)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when enabling depositing for a non-existing pool', async () => {
@@ -482,7 +482,7 @@ describe('PoolCollection', () => {
             it('should revert when a non-owner attempts to set the deposit limit', async () => {
                 await expect(
                     poolCollection.connect(nonOwner).setDepositLimit(reserveToken.address, newDepositLimit)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when setting the deposit limit of a non-existing pool', async () => {
@@ -889,7 +889,7 @@ describe('PoolCollection', () => {
                     poolCollection
                         .connect(nonNetwork)
                         .depositFor(provider.address, reserveToken.address, BigNumber.from(1), BigNumber.from(2))
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when attempting to deposit for an invalid provider', async () => {
@@ -1232,7 +1232,7 @@ describe('PoolCollection', () => {
                     poolCollection
                         .connect(nonNetwork)
                         .withdraw(reserveToken.address, BigNumber.from(1), BigNumber.from(1), BigNumber.from(1))
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when attempting to withdraw from an invalid pool', async () => {
@@ -1347,7 +1347,7 @@ describe('PoolCollection', () => {
                         poolCollection
                             .connect(nonNetwork)
                             .trade(sourceToken.address, targetToken.address, BigNumber.from(1), MIN_RETURN_AMOUNT)
-                    ).to.be.revertedWith('AccessDenied');
+                    ).to.be.revertedWith('AccessControl');
                 });
 
                 it('should revert when attempting to trade or query using an invalid source pool', async () => {
@@ -1999,7 +1999,7 @@ describe('PoolCollection', () => {
 
             await expect(
                 poolCollection.connect(nonNetwork).onFeesCollected(reserveToken.address, BigNumber.from(1))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to notify about collected fee from an invalid pool', async () => {
@@ -2064,7 +2064,7 @@ describe('PoolCollection', () => {
                 const poolData = await poolCollection.poolData(reserveToken.address);
                 await expect(
                     targetPoolCollection.connect(nonUpgrader).migratePoolIn(reserveToken.address, poolData)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when attempting to migrate an invalid pool into a pool collection', async () => {
@@ -2086,7 +2086,7 @@ describe('PoolCollection', () => {
 
                 await expect(
                     poolCollectionUpgrader.migratePoolInT(targetPoolCollection.address, reserveToken.address, poolData)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should allow to migrate a pool into a pool collection', async () => {
@@ -2126,7 +2126,7 @@ describe('PoolCollection', () => {
                     poolCollection
                         .connect(nonUpgrader)
                         .migratePoolOut(reserveToken.address, targetPoolCollection.address)
-                ).to.be.revertedWith('AccessDenied');
+                ).to.be.revertedWith('AccessControl');
             });
 
             it('should revert when attempting to migrate an invalid pool out of a pool collection', async () => {

--- a/packages/v3/test/pools/PoolCollectionUpgrader.ts
+++ b/packages/v3/test/pools/PoolCollectionUpgrader.ts
@@ -73,7 +73,7 @@ describe('PoolCollectionUpgrader', () => {
 
             await expect(
                 poolCollectionUpgrader.connect(nonNetwork).upgradePool(reserveToken.address)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting upgrade an invalid pool', async () => {

--- a/packages/v3/test/pools/PoolToken.ts
+++ b/packages/v3/test/pools/PoolToken.ts
@@ -64,7 +64,7 @@ describe('PoolToken', () => {
 
         it('should revert when a non owner attempts to issue tokens', async () => {
             await expect(poolToken.connect(nonOwner).mint(owner.address, BigNumber.from(1))).to.be.revertedWith(
-                'AccessDenied'
+                'AccessControl'
             );
         });
     });

--- a/packages/v3/test/pools/PoolTokenFactory.ts
+++ b/packages/v3/test/pools/PoolTokenFactory.ts
@@ -62,7 +62,7 @@ describe('PoolTokenFactory', () => {
         it('should revert when a non-owner attempts to set a token symbol override', async () => {
             await expect(
                 poolTokenFactory.connect(nonOwner).setTokenSymbolOverride(reserveToken.address, newSymbol)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should be able to set and update a token symbol override', async () => {
@@ -94,7 +94,7 @@ describe('PoolTokenFactory', () => {
         it('should revert when a non-owner attempts to set a token decimal override', async () => {
             await expect(
                 poolTokenFactory.connect(nonOwner).setTokenDecimalsOverride(reserveToken.address, newDecimals)
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should be able to set and update a token decimal override', async () => {

--- a/packages/v3/test/utility/Owned.ts
+++ b/packages/v3/test/utility/Owned.ts
@@ -52,7 +52,7 @@ describe('Owned', () => {
     });
 
     it('verifies that only the owner can initiate ownership transfer', async () => {
-        await expect(contract.connect(nonOwner).transferOwnership(newOwner.address)).to.be.revertedWith('AccessDenied');
+        await expect(contract.connect(nonOwner).transferOwnership(newOwner.address)).to.be.revertedWith('AccessControl');
     });
 
     it('verifies that the owner can cancel ownership transfer before the new owner accepted it', async () => {

--- a/packages/v3/test/utility/TokenHolder.ts
+++ b/packages/v3/test/utility/TokenHolder.ts
@@ -72,7 +72,7 @@ describe('TokenHolder', () => {
                 it('should revert when a non-owner attempts to withdraw', async () => {
                     await expect(
                         holder.connect(nonOwner).withdrawTokens(asset.address, receiver.address, BigNumber.from(1))
-                    ).to.be.revertedWith('AccessDenied');
+                    ).to.be.revertedWith('AccessControl');
                 });
 
                 it('should revert when attempting to withdraw with an invalid asset address', async () => {
@@ -130,7 +130,7 @@ describe('TokenHolder', () => {
                 holder
                     .connect(nonOwner)
                     .withdrawTokensMultiple(assetAddresses, receiver.address, Object.values(amounts))
-            ).to.be.revertedWith('AccessDenied');
+            ).to.be.revertedWith('AccessControl');
         });
 
         it('should revert when attempting to withdraw with an invalid asset address', async () => {

--- a/packages/v3/test/utility/Upgradeable.ts
+++ b/packages/v3/test/utility/Upgradeable.ts
@@ -33,6 +33,6 @@ describe('Upgradeable', () => {
     });
 
     it('should revert when a non-owner is attempting to call a restricted function', async () => {
-        await expect(upgradeable.connect(nonOwner).restricted()).to.be.revertedWith('AccessDenied');
+        await expect(upgradeable.connect(nonOwner).restricted()).to.be.revertedWith('AccessControl');
     });
 });


### PR DESCRIPTION
This PR consists of the following two changes:
1. Replace proprietary `onlyAdmin` with custom (OZ) `onlyRole(ROLE_ADMIN)`.
2. Replace all `AccessDenied` errors with `AccessControl`, in order for them to be the same as the errors emitted by `onlyRole`.

I'm a little skeptic about the 2nd change.

After applying the 1st change, I needed to apply the 2nd change in some of the tests.
Instead, I chose to apply it in all of the tests AND in all of the contracts.

On the one hand, it makes all errors which are generally the result of an illegal access attempt start with the same prefix, namely - `AccessControl`, which might be considered a positive generalization (our own specific errors will consist of only this prefix, while OZ errors will consist of this prefix + some additional information).

On the other hand, it might be harder for us to distinguish between cases which reverted directly due to `onlyRole`, and cases which reverted due to other reasons.

If you think that we should maintain a different prefix (AccessDenied) for our specific (non-onlyRole) errors, then we can revert some of the above (i.e., replace only some of the `AccessDenied` occurrences with `AccessControl`, and only in the tests).