### PR TITLE
Unify Legacy Contract Importing

### DIFF
--- a/packages/v3/components/LegacyContracts.ts
+++ b/packages/v3/components/LegacyContracts.ts
@@ -24,13 +24,14 @@ import {
     DSToken__factory as GovToken__factory,
     SmartToken as NetworkToken,
     SmartToken__factory as NetworkToken__factory,
+    TokenGovernance,
     TokenGovernance__factory
 } from '@bancor/token-governance';
 import { Signer } from 'ethers';
 
 /* eslint-enable camelcase */
 
-export { NetworkToken, GovToken };
+export { NetworkToken, GovToken, TokenGovernance };
 
 export {
     ConverterFactory,

--- a/packages/v3/test/helpers/Factory.ts
+++ b/packages/v3/test/helpers/Factory.ts
@@ -1,6 +1,7 @@
 import { ContractBuilder, Contract } from '../../components/ContractBuilder';
 import Contracts from '../../components/Contracts';
 import LegacyContracts from '../../components/LegacyContracts';
+import { TokenGovernance } from '../../components/LegacyContracts';
 import {
     BancorVault,
     NetworkSettings,
@@ -14,7 +15,6 @@ import { roles } from './AccessControl';
 import { NATIVE_TOKEN_ADDRESS, MAX_UINT256, DEFAULT_DECIMALS, BNT, vBNT } from './Constants';
 import { Fraction } from './Types';
 import { toAddress, TokenWithAddress, createTokenBySymbol } from './Utils';
-import { TokenGovernance } from '@bancor/token-governance';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { BaseContract, BigNumber, ContractFactory } from 'ethers';
 import { ethers, waffle } from 'hardhat';

--- a/packages/v3/test/network/BancorNetwork.ts
+++ b/packages/v3/test/network/BancorNetwork.ts
@@ -1,6 +1,6 @@
 import { AsyncReturnType } from '../../components/ContractBuilder';
 import Contracts from '../../components/Contracts';
-import { GovToken, NetworkToken } from '../../components/LegacyContracts';
+import { GovToken, NetworkToken, TokenGovernance } from '../../components/LegacyContracts';
 import {
     BancorVault,
     NetworkSettings,
@@ -39,7 +39,6 @@ import {
     transfer,
     TokenWithAddress
 } from '../helpers/Utils';
-import { TokenGovernance } from '@bancor/token-governance';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction, Signer, utils, Wallet } from 'ethers';

--- a/packages/v3/test/pools/NetworkTokenPool.ts
+++ b/packages/v3/test/pools/NetworkTokenPool.ts
@@ -1,5 +1,5 @@
 import Contracts from '../../components/Contracts';
-import { NetworkToken, GovToken } from '../../components/LegacyContracts';
+import { NetworkToken, GovToken, TokenGovernance } from '../../components/LegacyContracts';
 import {
     BancorVault,
     NetworkSettings,
@@ -25,7 +25,6 @@ import { mulDivF } from '../helpers/MathUtils';
 import { shouldHaveGap } from '../helpers/Proxy';
 import { toWei } from '../helpers/Types';
 import { createTokenBySymbol, TokenWithAddress, transfer } from '../helpers/Utils';
-import { TokenGovernance } from '@bancor/token-governance';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { BigNumber, utils } from 'ethers';


### PR DESCRIPTION
Import the `TokenGovernance` artifact from the `LegacyContract` utility instead of directly from `node_modules`.