### PR TITLE
Remove unused functions `MathEx.ceilSqrt` and `MathEx.productRatio`

### DIFF
--- a/packages/v3/contracts/helpers/TestMathEx.sol
+++ b/packages/v3/contracts/helpers/TestMathEx.sol
@@ -10,14 +10,6 @@ contract TestMathEx {
         return MathEx.floorSqrt(num);
     }
 
-    function ceilSqrt(uint256 num) external pure returns (uint256) {
-        return MathEx.ceilSqrt(num);
-    }
-
-    function productRatio(Fraction memory x, Fraction memory y) external pure returns (Fraction memory) {
-        return MathEx.productRatio(x, y);
-    }
-
     function reducedRatio(Fraction memory r, uint256 max) external pure returns (Fraction memory) {
         return MathEx.reducedRatio(r, max);
     }

--- a/packages/v3/contracts/utility/MathEx.sol
+++ b/packages/v3/contracts/utility/MathEx.sol
@@ -35,16 +35,6 @@ library MathEx {
     }
 
     /**
-     * @dev returns the smallest integer larger than or equal to the square root of a positive integer
-     */
-    function ceilSqrt(uint256 n) internal pure returns (uint256) {
-        unchecked {
-            uint256 x = floorSqrt(n);
-            return x * x == n ? x : x + 1;
-        }
-    }
-
-    /**
      * @dev returns an `Sint256` positive representation of an unsigned integer
      */
     function toPos256(uint256 n) internal pure returns (Sint256 memory) {
@@ -56,21 +46,6 @@ library MathEx {
      */
     function toNeg256(uint256 n) internal pure returns (Sint256 memory) {
         return Sint256({ value: n, isNeg: true });
-    }
-
-    /**
-     * @dev computes the product of two given ratios
-     */
-    function productRatio(Fraction memory x, Fraction memory y) internal pure returns (Fraction memory) {
-        unchecked {
-            uint256 n = mulDivC(x.n, y.n, type(uint256).max);
-            uint256 d = mulDivC(x.d, y.d, type(uint256).max);
-            uint256 z = n > d ? n : d;
-            if (z > 1) {
-                return Fraction({ n: mulDivC(x.n, y.n, z), d: mulDivC(x.d, y.d, z) });
-            }
-            return Fraction({ n: x.n * y.n, d: x.d * y.d });
-        }
     }
 
     /**

--- a/packages/v3/test/helpers/MathUtils.ts
+++ b/packages/v3/test/helpers/MathUtils.ts
@@ -10,12 +10,6 @@ const decimalize = <C>(func: Function) => {
 
 export const floorSqrt = decimalize<Decimal>((n: Decimal) => n.sqrt().floor());
 
-export const ceilSqrt = decimalize<Decimal>((n: Decimal) => n.sqrt().ceil());
-
-export const productRatio = decimalize<Decimal>(
-    (a: Fraction, b: Fraction): Fraction => ({ n: a.n.mul(b.n), d: a.d.mul(b.d) })
-);
-
 export const reducedRatio = decimalize<Fraction<Decimal>>((r: Fraction, max: Decimal): Fraction => {
     if (r.n.gt(max) || r.d.gt(max)) {
         return normalizedRatio(r, max);

--- a/packages/v3/test/utility/MathEx.ts
+++ b/packages/v3/test/utility/MathEx.ts
@@ -2,8 +2,6 @@ import Contracts from '../../components/Contracts';
 import { TestMathEx } from '../../typechain-types';
 import {
     floorSqrt,
-    ceilSqrt,
-    productRatio,
     reducedRatio,
     normalizedRatio,
     accurateRatio,
@@ -42,23 +40,6 @@ describe('MathEx', () => {
             const expected = floorSqrt(x);
             const actual = await mathContract.floorSqrt(x);
             expect(actual).to.equal(expected);
-        });
-    };
-
-    const testCeilSqrt = (n: number, k: number) => {
-        const x = BigNumber.from(2).pow(n).add(k);
-        it(`ceilSqrt(${x.toHexString()})`, async () => {
-            const expected = ceilSqrt(x);
-            const actual = await mathContract.ceilSqrt(x);
-            expect(actual).to.equal(expected);
-        });
-    };
-
-    const testProductRatio = (x: Fraction, y: Fraction, maxAbsoluteError: Decimal, maxRelativeError: Decimal) => {
-        it(`productRatio(${toString(x)}, ${toString(y)}`, async () => {
-            const expected = productRatio(x, y);
-            const actual = await mathContract.productRatio(toBigNumber(x), toBigNumber(y));
-            expect(expected).to.almostEqual({ n: actual[0], d: actual[1] }, { maxAbsoluteError, maxRelativeError });
         });
     };
 
@@ -164,22 +145,6 @@ describe('MathEx', () => {
             }
         }
 
-        for (const n of [1, 64, 128, 192, 256]) {
-            for (const k of n < 256 ? [-1, 0, +1] : [-1]) {
-                testCeilSqrt(n, k);
-            }
-        }
-
-        for (const xn of PR_TEST_ARRAY.slice(-2)) {
-            for (const yn of PR_TEST_ARRAY.slice(-2)) {
-                for (const xd of PR_TEST_ARRAY.slice(-2)) {
-                    for (const yd of PR_TEST_ARRAY.slice(-2)) {
-                        testProductRatio({ n: xn, d: xd }, { n: yn, d: yd }, new Decimal(0), PR_MAX_ERROR);
-                    }
-                }
-            }
-        }
-
         for (const scale of SCALES) {
             for (let a = 0; a < 5; a++) {
                 for (let b = 1; b <= 5; b++) {
@@ -255,22 +220,6 @@ describe('MathEx', () => {
         for (let n = 1; n <= 256; n++) {
             for (const k of n < 256 ? [-1, 0, +1] : [-1]) {
                 testFloorSqrt(n, k);
-            }
-        }
-
-        for (let n = 1; n <= 256; n++) {
-            for (const k of n < 256 ? [-1, 0, +1] : [-1]) {
-                testCeilSqrt(n, k);
-            }
-        }
-
-        for (const xn of PR_TEST_ARRAY) {
-            for (const yn of PR_TEST_ARRAY) {
-                for (const xd of PR_TEST_ARRAY) {
-                    for (const yd of PR_TEST_ARRAY) {
-                        testProductRatio({ n: xn, d: xd }, { n: yn, d: yd }, new Decimal(0), PR_MAX_ERROR);
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
Performing the `MathEx` cleanup is several phases, in order to make it reviewable faster and easier.

Phase 1: removing unused functions `MathEx.ceilSqrt` and `MathEx.productRatio` (library and tests).