### PR TITLE
Extract liquidity migration tests to a scope of its own

### DIFF
--- a/packages/v3/test/network/BancorNetwork.ts
+++ b/packages/v3/test/network/BancorNetwork.ts
@@ -1628,463 +1628,6 @@ describe('BancorNetwork', () => {
                 testDeposits(symbol);
             });
         }
-
-        const testLiquidityMigration = (
-            totalSupply: BigNumber,
-            reserve1Amount: BigNumber,
-            reserve2Amount: BigNumber,
-            maxRelativeError: Decimal,
-            maxOffset: { negative: number; positive: number }
-        ) => {
-            let now: number;
-            let checkpointStore: TestCheckpointStore;
-            let liquidityProtectionSettings: LiquidityProtectionSettings;
-            let liquidityProtectionStore: LiquidityProtectionStore;
-            let liquidityProtectionStats: LiquidityProtectionStats;
-            let liquidityProtectionSystemStore: LiquidityProtectionSystemStore;
-            let liquidityProtectionWallet: TokenHolder;
-            let liquidityProtection: TestLiquidityProtection;
-            let converter: TestStandardPoolConverter;
-            let poolToken: DSToken;
-            let baseToken: IERC20;
-            let owner: SignerWithAddress;
-            let provider: SignerWithAddress;
-
-            const expectInRange = (x: BigNumber, y: BigNumber) => {
-                expect(x).to.gte(y.sub(maxOffset.negative));
-                expect(x).to.lte(y.add(maxOffset.positive));
-            };
-
-            const addProtectedLiquidity = async (
-                poolTokenAddress: string,
-                token: IERC20,
-                tokenAddress: string,
-                amount: BigNumber,
-                isETH: boolean,
-                from: SignerWithAddress
-            ) => {
-                let value = BigNumber.from(0);
-                if (isETH) {
-                    value = amount;
-                } else {
-                    await token.connect(from).approve(liquidityProtection.address, amount);
-                }
-
-                return liquidityProtection
-                    .connect(from)
-                    .addLiquidity(poolTokenAddress, tokenAddress, amount, { value });
-            };
-
-            const getProtection = async (protectionId: BigNumber) => {
-                const protection = await liquidityProtectionStore.protectedLiquidity(protectionId);
-                return {
-                    provider: protection[0],
-                    poolToken: protection[1],
-                    reserveToken: protection[2],
-                    poolAmount: protection[3],
-                    reserveAmount: protection[4],
-                    reserveRateN: protection[5],
-                    reserveRateD: protection[6],
-                    timestamp: protection[7]
-                };
-            };
-
-            const getPoolStats = async (
-                poolToken: TokenWithAddress,
-                reserveToken: TokenWithAddress,
-                isETH: boolean
-            ) => {
-                const poolTokenAddress = poolToken.address;
-                const reserveTokenAddress = isETH ? NATIVE_TOKEN_ADDRESS : reserveToken.address;
-                return {
-                    totalPoolAmount: await liquidityProtectionStats.totalPoolAmount(poolTokenAddress),
-                    totalReserveAmount: await liquidityProtectionStats.totalReserveAmount(
-                        poolTokenAddress,
-                        reserveTokenAddress
-                    )
-                };
-            };
-
-            const getProviderStats = async (
-                provider: SignerWithAddress,
-                poolToken: TokenWithAddress,
-                reserveToken: TokenWithAddress,
-                isETH: boolean
-            ) => {
-                const poolTokenAddress = poolToken.address;
-                const reserveTokenAddress = isETH ? NATIVE_TOKEN_ADDRESS : reserveToken.address;
-                return {
-                    totalProviderAmount: await liquidityProtectionStats.totalProviderAmount(
-                        provider.address,
-                        poolTokenAddress,
-                        reserveTokenAddress
-                    ),
-                    providerPools: await liquidityProtectionStats.providerPools(provider.address)
-                };
-            };
-
-            const setTime = async (time: number) => {
-                now = time;
-
-                for (const t of [converter, checkpointStore, liquidityProtection]) {
-                    if (t) {
-                        await t.setTime(now);
-                    }
-                }
-            };
-
-            const initLegacySystem = async (isETH: boolean) => {
-                [owner, provider] = await ethers.getSigners();
-
-                baseToken = (await createTokenBySymbol(isETH ? ETH : TKN)) as IERC20;
-
-                ({
-                    checkpointStore,
-                    liquidityProtectionStore,
-                    liquidityProtectionStats,
-                    liquidityProtectionSystemStore,
-                    liquidityProtectionWallet,
-                    liquidityProtectionSettings,
-                    liquidityProtection,
-                    poolToken,
-                    converter
-                } = await createLegacySystem(
-                    owner,
-                    network,
-                    masterVault,
-                    networkToken,
-                    networkTokenGovernance,
-                    govTokenGovernance,
-                    baseToken
-                ));
-
-                await networkTokenGovernance.mint(owner.address, totalSupply);
-
-                await liquidityProtectionSettings.setMinNetworkTokenLiquidityForMinting(100);
-                await liquidityProtectionSettings.setMinNetworkCompensation(3);
-
-                await network.grantRole(BancorNetworkRoles.ROLE_MIGRATION_MANAGER, liquidityProtection.address);
-                await networkTokenGovernance.grantRole(roles.TokenGovernance.ROLE_MINTER, liquidityProtection.address);
-                await govTokenGovernance.grantRole(roles.TokenGovernance.ROLE_MINTER, liquidityProtection.address);
-
-                await createPool(baseToken, network, networkSettings, poolCollection);
-                await networkSettings.setPoolMintingLimit(baseToken.address, MINTING_LIMIT);
-                await poolCollection.setDepositLimit(baseToken.address, DEPOSIT_LIMIT);
-                await poolCollection.setInitialRate(baseToken.address, INITIAL_RATE);
-
-                await networkToken.approve(converter.address, reserve2Amount);
-
-                let value = BigNumber.from(0);
-                if (isETH) {
-                    value = reserve1Amount;
-                } else {
-                    await baseToken.approve(converter.address, reserve1Amount);
-                }
-
-                await converter.addLiquidity(
-                    [baseToken.address, networkToken.address],
-                    [reserve1Amount, reserve2Amount],
-                    1,
-                    {
-                        value: value
-                    }
-                );
-
-                await liquidityProtectionSettings.addPoolToWhitelist(poolToken.address);
-
-                await setTime(await latest());
-            };
-
-            for (const isETH of [false, true]) {
-                describe(`base token (${isETH ? 'ETH' : 'ERC20'})`, () => {
-                    beforeEach(async () => {
-                        await initLegacySystem(isETH);
-                        await addProtectedLiquidity(
-                            poolToken.address,
-                            baseToken,
-                            baseToken.address,
-                            BigNumber.from(1000),
-                            isETH,
-                            owner
-                        );
-                    });
-
-                    it('verifies that the caller cannot migrate a position more than once in the same transaction', async () => {
-                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                        await liquidityProtection.setTime(now + duration.seconds(1));
-                        await expect(
-                            liquidityProtection.migratePositions([protectionId, protectionId])
-                        ).to.be.revertedWith('ERR_ACCESS_DENIED');
-                    });
-
-                    it('verifies that the caller cannot migrate a position more than once in different transactions', async () => {
-                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                        await liquidityProtection.setTime(now + duration.seconds(1));
-                        await liquidityProtection.migratePositions([protectionId]);
-                        await expect(liquidityProtection.migratePositions([protectionId])).to.be.revertedWith(
-                            'ERR_ACCESS_DENIED'
-                        );
-                    });
-
-                    it('verifies that the caller can migrate positions', async () => {
-                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                        const protection = await getProtection(protectionId);
-
-                        const prevPoolStats = await getPoolStats(poolToken, baseToken, isETH);
-                        const prevProviderStats = await getProviderStats(owner, poolToken, baseToken, isETH);
-
-                        const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-
-                        const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                        const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-
-                        await liquidityProtection.setTime(now + duration.seconds(1));
-
-                        const prevWalletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
-                        const prevBalance = await getBalance(baseToken, owner.address);
-                        const prevGovBalance = await govToken.balanceOf(owner.address);
-
-                        const res = await liquidityProtection.migratePositions([protectionId]);
-                        const transactionCost = isETH ? await getTransactionCost(res) : BigNumber.from(0);
-
-                        // verify protected liquidities
-                        expect(await liquidityProtectionStore.protectedLiquidityIds(owner.address)).to.be.empty;
-
-                        // verify stats
-                        const poolStats = await getPoolStats(poolToken, baseToken, isETH);
-                        expect(poolStats.totalPoolAmount).to.equal(
-                            prevPoolStats.totalPoolAmount.sub(protection.poolAmount)
-                        );
-                        expect(poolStats.totalReserveAmount).to.equal(
-                            prevPoolStats.totalReserveAmount.sub(protection.reserveAmount)
-                        );
-
-                        const providerStats = await getProviderStats(owner, poolToken, baseToken, isETH);
-                        expect(providerStats.totalProviderAmount).to.equal(
-                            prevProviderStats.totalProviderAmount.sub(protection.reserveAmount)
-                        );
-                        expect(providerStats.providerPools).to.deep.equal([poolToken.address]);
-
-                        // verify balances
-                        const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-                        expectInRange(systemBalance, prevSystemBalance.sub(protection.poolAmount));
-
-                        const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                        const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-                        expectInRange(vaultBaseBalance, prevVaultBaseBalance.add(protection.reserveAmount));
-                        expectInRange(
-                            vaultNetworkBalance,
-                            prevVaultNetworkBalance.add(protection.reserveAmount.div(2))
-                        );
-
-                        const walletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
-
-                        // double since system balance was also liquidated
-                        const delta = protection.poolAmount.mul(2);
-                        expectInRange(walletBalance, prevWalletBalance.sub(delta));
-
-                        const balance = await getBalance(baseToken, owner.address);
-                        expect(balance).to.equal(prevBalance.sub(transactionCost));
-
-                        const govBalance = await govToken.balanceOf(owner.address);
-                        expect(govBalance).to.equal(prevGovBalance);
-
-                        const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
-                        expect(protectionPoolBalance).to.equal(0);
-
-                        const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
-                        expect(protectionBaseBalance).to.equal(0);
-
-                        const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
-                        expect(protectionNetworkBalance).to.equal(0);
-                    });
-
-                    it('verifies that the owner can migrate system pool tokens', async () => {
-                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                        const protection = await getProtection(protectionId);
-
-                        const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-
-                        const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                        const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-
-                        await liquidityProtection.setTime(now + duration.seconds(1));
-
-                        const prevGovBalance = await govToken.balanceOf(owner.address);
-
-                        await liquidityProtection.migrateSystemPoolTokens([poolToken.address]);
-
-                        // verify balances
-                        const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-                        expect(systemBalance).to.equal(prevSystemBalance.sub(protection.poolAmount));
-
-                        const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                        const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-                        expect(vaultBaseBalance).to.equal(prevVaultBaseBalance.add(protection.reserveAmount.div(2)));
-                        expect(vaultNetworkBalance).to.equal(prevVaultNetworkBalance);
-
-                        const govBalance = await govToken.balanceOf(owner.address);
-                        expect(govBalance).to.equal(prevGovBalance);
-
-                        const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
-                        expect(protectionPoolBalance).to.equal(0);
-
-                        const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
-                        expect(protectionBaseBalance).to.equal(0);
-
-                        const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
-                        expect(protectionNetworkBalance).to.equal(0);
-                    });
-                });
-            }
-
-            describe('network token', () => {
-                beforeEach(async () => {
-                    await initLegacySystem(false);
-
-                    const amount = BigNumber.from(100_000);
-                    await baseToken.transfer(provider.address, amount);
-                    await baseToken.connect(provider).approve(network.address, amount);
-                    await network.connect(provider).deposit(baseToken.address, amount);
-
-                    const amount1 = BigNumber.from(5000);
-                    await baseToken.transfer(provider.address, amount1);
-                    await addProtectedLiquidity(
-                        poolToken.address,
-                        baseToken,
-                        baseToken.address,
-                        amount1,
-                        false,
-                        provider
-                    );
-
-                    const amount2 = BigNumber.from(1000);
-                    await addProtectedLiquidity(
-                        poolToken.address,
-                        networkToken,
-                        networkToken.address,
-                        amount2,
-                        false,
-                        owner
-                    );
-                });
-
-                it('verifies that the caller cannot migrate a position more than once in the same transaction', async () => {
-                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                    await liquidityProtection.setTime(now + duration.seconds(1));
-                    await expect(liquidityProtection.migratePositions([protectionId, protectionId])).to.be.revertedWith(
-                        'ERR_ACCESS_DENIED'
-                    );
-                });
-
-                it('verifies that the caller cannot migrate a position more than once in different transactions', async () => {
-                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                    await liquidityProtection.setTime(now + duration.seconds(1));
-                    await liquidityProtection.migratePositions([protectionId]);
-                    await expect(liquidityProtection.migratePositions([protectionId])).to.be.revertedWith(
-                        'ERR_ACCESS_DENIED'
-                    );
-                });
-
-                it('verifies that the caller can migrate positions', async () => {
-                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
-                    const protection = await getProtection(protectionId);
-
-                    const prevPoolStats = await getPoolStats(poolToken, networkToken, false);
-                    const prevProviderStats = await getProviderStats(owner, poolToken, networkToken, false);
-                    const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-                    const prevWalletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
-                    const prevBalance = await getBalance(networkToken, owner.address);
-                    const prevGovBalance = await govToken.balanceOf(owner.address);
-
-                    const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                    const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-
-                    await liquidityProtection.setTime(now + duration.seconds(1));
-                    await liquidityProtection.migratePositions([protectionId]);
-
-                    // verify protected liquidities
-                    expect(await liquidityProtectionStore.protectedLiquidityIds(owner.address)).to.be.empty;
-
-                    // verify stats
-                    const poolStats = await getPoolStats(poolToken, networkToken, false);
-                    expect(poolStats.totalPoolAmount).to.equal(prevSystemBalance.add(protection.poolAmount));
-                    expect(poolStats.totalReserveAmount).to.equal(
-                        prevPoolStats.totalReserveAmount.sub(protection.reserveAmount)
-                    );
-
-                    const providerStats = await getProviderStats(owner, poolToken, networkToken, false);
-                    expect(providerStats.totalProviderAmount).to.equal(
-                        prevProviderStats.totalProviderAmount.sub(protection.reserveAmount)
-                    );
-                    expect(prevProviderStats.providerPools).to.deep.equal([poolToken.address]);
-
-                    // verify balances
-                    const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
-                    expect(systemBalance).to.equal(prevSystemBalance.add(protection.poolAmount));
-
-                    const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
-                    const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
-                    expect(vaultBaseBalance).to.equal(prevVaultBaseBalance);
-                    expect(vaultNetworkBalance).to.equal(prevVaultNetworkBalance);
-
-                    const walletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
-                    expect(walletBalance).to.equal(prevWalletBalance);
-
-                    const balance = await getBalance(networkToken, owner.address);
-                    expect(balance).to.almostEqual(new Decimal(prevBalance.add(protection.reserveAmount).toString()), {
-                        maxRelativeError
-                    });
-
-                    const govBalance = await govToken.balanceOf(owner.address);
-                    expect(govBalance).to.equal(prevGovBalance);
-
-                    const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
-                    expect(protectionPoolBalance).to.equal(0);
-
-                    const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
-                    expect(protectionBaseBalance).to.equal(0);
-
-                    const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
-                    expectInRange(protectionNetworkBalance, BigNumber.from(0));
-                });
-            });
-        };
-
-        for (const { totalSupply, reserve1Amount, reserve2Amount, maxRelativeError, maxOffset } of [
-            {
-                totalSupply: BigNumber.from(10_000_000),
-                reserve1Amount: BigNumber.from(1_000_000),
-                reserve2Amount: BigNumber.from(2_500_000),
-                maxRelativeError: new Decimal('0.000000000000000000000001'),
-                maxOffset: { negative: 0, positive: 0 }
-            },
-            {
-                totalSupply: toWei(10_000_000),
-                reserve1Amount: BigNumber.from(1_000_000),
-                reserve2Amount: BigNumber.from(2_500_000),
-                maxRelativeError: new Decimal('0.000000000000000000000001'),
-                maxOffset: { negative: 0, positive: 0 }
-            },
-            {
-                totalSupply: BigNumber.from(10_000_000),
-                reserve1Amount: toWei(1_000_000),
-                reserve2Amount: toWei(2_500_000),
-                maxRelativeError: new Decimal('0.000000000000000000000001003'),
-                maxOffset: { negative: 1, positive: 1 }
-            },
-            {
-                totalSupply: toWei(10_000_000),
-                reserve1Amount: toWei(1_000_000),
-                reserve2Amount: toWei(2_500_000),
-                maxRelativeError: new Decimal('0.000000000000000000000001'),
-                maxOffset: { negative: 1, positive: 1 }
-            }
-        ]) {
-            describe(`migrate liquidity (totalSupply = ${totalSupply}, reserve1Amount = ${reserve1Amount}, reserve2Amount = ${reserve2Amount})`, () => {
-                testLiquidityMigration(totalSupply, reserve1Amount, reserve2Amount, maxRelativeError, maxOffset);
-            });
-        }
     });
 
     describe('withdraw', () => {
@@ -3385,6 +2928,504 @@ describe('BancorNetwork', () => {
                     testFlashLoan(symbol, toPPM(flashLoanFee));
                 });
             }
+        }
+    });
+
+    describe('migrate liquidity', () => {
+        let networkTokenGovernance: TokenGovernance;
+        let govTokenGovernance: TokenGovernance;
+        let network: TestBancorNetwork;
+        let networkSettings: NetworkSettings;
+        let networkToken: IERC20;
+        let govToken: IERC20;
+        let poolCollection: TestPoolCollection;
+        let masterVault: MasterVault;
+
+        const MAX_DEVIATION = toPPM(1);
+        const MINTING_LIMIT = toWei(10_000_000);
+        const WITHDRAWAL_FEE = toPPM(5);
+        const MIN_LIQUIDITY_FOR_TRADING = toWei(100_000);
+        const DEPOSIT_LIMIT = toWei(100_000_000);
+
+        const setup = async () => {
+            ({
+                networkTokenGovernance,
+                govTokenGovernance,
+                network,
+                networkSettings,
+                networkToken,
+                govToken,
+                poolCollection,
+                masterVault
+            } = await createSystem());
+
+            await networkSettings.setAverageRateMaxDeviationPPM(MAX_DEVIATION);
+            await networkSettings.setWithdrawalFeePPM(WITHDRAWAL_FEE);
+            await networkSettings.setMinLiquidityForTrading(MIN_LIQUIDITY_FOR_TRADING);
+        };
+
+        beforeEach(async () => {
+            await waffle.loadFixture(setup);
+        });
+
+        const testLiquidityMigration = (
+            totalSupply: BigNumber,
+            reserve1Amount: BigNumber,
+            reserve2Amount: BigNumber,
+            maxRelativeError: Decimal,
+            maxOffset: { negative: number; positive: number }
+        ) => {
+            let now: number;
+            let checkpointStore: TestCheckpointStore;
+            let liquidityProtectionSettings: LiquidityProtectionSettings;
+            let liquidityProtectionStore: LiquidityProtectionStore;
+            let liquidityProtectionStats: LiquidityProtectionStats;
+            let liquidityProtectionSystemStore: LiquidityProtectionSystemStore;
+            let liquidityProtectionWallet: TokenHolder;
+            let liquidityProtection: TestLiquidityProtection;
+            let converter: TestStandardPoolConverter;
+            let poolToken: DSToken;
+            let baseToken: IERC20;
+            let owner: SignerWithAddress;
+            let provider: SignerWithAddress;
+
+            const expectInRange = (x: BigNumber, y: BigNumber) => {
+                expect(x).to.gte(y.sub(maxOffset.negative));
+                expect(x).to.lte(y.add(maxOffset.positive));
+            };
+
+            const addProtectedLiquidity = async (
+                poolTokenAddress: string,
+                token: IERC20,
+                tokenAddress: string,
+                amount: BigNumber,
+                isETH: boolean,
+                from: SignerWithAddress
+            ) => {
+                let value = BigNumber.from(0);
+                if (isETH) {
+                    value = amount;
+                } else {
+                    await token.connect(from).approve(liquidityProtection.address, amount);
+                }
+
+                return liquidityProtection
+                    .connect(from)
+                    .addLiquidity(poolTokenAddress, tokenAddress, amount, { value });
+            };
+
+            const getProtection = async (protectionId: BigNumber) => {
+                const protection = await liquidityProtectionStore.protectedLiquidity(protectionId);
+                return {
+                    provider: protection[0],
+                    poolToken: protection[1],
+                    reserveToken: protection[2],
+                    poolAmount: protection[3],
+                    reserveAmount: protection[4],
+                    reserveRateN: protection[5],
+                    reserveRateD: protection[6],
+                    timestamp: protection[7]
+                };
+            };
+
+            const getPoolStats = async (
+                poolToken: TokenWithAddress,
+                reserveToken: TokenWithAddress,
+                isETH: boolean
+            ) => {
+                const poolTokenAddress = poolToken.address;
+                const reserveTokenAddress = isETH ? NATIVE_TOKEN_ADDRESS : reserveToken.address;
+                return {
+                    totalPoolAmount: await liquidityProtectionStats.totalPoolAmount(poolTokenAddress),
+                    totalReserveAmount: await liquidityProtectionStats.totalReserveAmount(
+                        poolTokenAddress,
+                        reserveTokenAddress
+                    )
+                };
+            };
+
+            const getProviderStats = async (
+                provider: SignerWithAddress,
+                poolToken: TokenWithAddress,
+                reserveToken: TokenWithAddress,
+                isETH: boolean
+            ) => {
+                const poolTokenAddress = poolToken.address;
+                const reserveTokenAddress = isETH ? NATIVE_TOKEN_ADDRESS : reserveToken.address;
+                return {
+                    totalProviderAmount: await liquidityProtectionStats.totalProviderAmount(
+                        provider.address,
+                        poolTokenAddress,
+                        reserveTokenAddress
+                    ),
+                    providerPools: await liquidityProtectionStats.providerPools(provider.address)
+                };
+            };
+
+            const setTime = async (time: number) => {
+                now = time;
+
+                for (const t of [converter, checkpointStore, liquidityProtection]) {
+                    if (t) {
+                        await t.setTime(now);
+                    }
+                }
+            };
+
+            const initLegacySystem = async (isETH: boolean) => {
+                [owner, provider] = await ethers.getSigners();
+
+                baseToken = (await createTokenBySymbol(isETH ? ETH : TKN)) as IERC20;
+
+                ({
+                    checkpointStore,
+                    liquidityProtectionStore,
+                    liquidityProtectionStats,
+                    liquidityProtectionSystemStore,
+                    liquidityProtectionWallet,
+                    liquidityProtectionSettings,
+                    liquidityProtection,
+                    poolToken,
+                    converter
+                } = await createLegacySystem(
+                    owner,
+                    network,
+                    masterVault,
+                    networkToken,
+                    networkTokenGovernance,
+                    govTokenGovernance,
+                    baseToken
+                ));
+
+                await networkTokenGovernance.mint(owner.address, totalSupply);
+
+                await liquidityProtectionSettings.setMinNetworkTokenLiquidityForMinting(100);
+                await liquidityProtectionSettings.setMinNetworkCompensation(3);
+
+                await network.grantRole(BancorNetworkRoles.ROLE_MIGRATION_MANAGER, liquidityProtection.address);
+                await networkTokenGovernance.grantRole(roles.TokenGovernance.ROLE_MINTER, liquidityProtection.address);
+                await govTokenGovernance.grantRole(roles.TokenGovernance.ROLE_MINTER, liquidityProtection.address);
+
+                await createPool(baseToken, network, networkSettings, poolCollection);
+                await networkSettings.setPoolMintingLimit(baseToken.address, MINTING_LIMIT);
+                await poolCollection.setDepositLimit(baseToken.address, DEPOSIT_LIMIT);
+                await poolCollection.setInitialRate(baseToken.address, INITIAL_RATE);
+
+                await networkToken.approve(converter.address, reserve2Amount);
+
+                let value = BigNumber.from(0);
+                if (isETH) {
+                    value = reserve1Amount;
+                } else {
+                    await baseToken.approve(converter.address, reserve1Amount);
+                }
+
+                await converter.addLiquidity(
+                    [baseToken.address, networkToken.address],
+                    [reserve1Amount, reserve2Amount],
+                    1,
+                    {
+                        value: value
+                    }
+                );
+
+                await liquidityProtectionSettings.addPoolToWhitelist(poolToken.address);
+
+                await setTime(await latest());
+            };
+
+            for (const isETH of [false, true]) {
+                describe(`base token (${isETH ? 'ETH' : 'ERC20'})`, () => {
+                    beforeEach(async () => {
+                        await initLegacySystem(isETH);
+                        await addProtectedLiquidity(
+                            poolToken.address,
+                            baseToken,
+                            baseToken.address,
+                            BigNumber.from(1000),
+                            isETH,
+                            owner
+                        );
+                    });
+
+                    it('verifies that the caller cannot migrate a position more than once in the same transaction', async () => {
+                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                        await liquidityProtection.setTime(now + duration.seconds(1));
+                        await expect(
+                            liquidityProtection.migratePositions([protectionId, protectionId])
+                        ).to.be.revertedWith('ERR_ACCESS_DENIED');
+                    });
+
+                    it('verifies that the caller cannot migrate a position more than once in different transactions', async () => {
+                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                        await liquidityProtection.setTime(now + duration.seconds(1));
+                        await liquidityProtection.migratePositions([protectionId]);
+                        await expect(liquidityProtection.migratePositions([protectionId])).to.be.revertedWith(
+                            'ERR_ACCESS_DENIED'
+                        );
+                    });
+
+                    it('verifies that the caller can migrate positions', async () => {
+                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                        const protection = await getProtection(protectionId);
+
+                        const prevPoolStats = await getPoolStats(poolToken, baseToken, isETH);
+                        const prevProviderStats = await getProviderStats(owner, poolToken, baseToken, isETH);
+
+                        const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+
+                        const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                        const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+
+                        await liquidityProtection.setTime(now + duration.seconds(1));
+
+                        const prevWalletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
+                        const prevBalance = await getBalance(baseToken, owner.address);
+                        const prevGovBalance = await govToken.balanceOf(owner.address);
+
+                        const res = await liquidityProtection.migratePositions([protectionId]);
+                        const transactionCost = isETH ? await getTransactionCost(res) : BigNumber.from(0);
+
+                        // verify protected liquidities
+                        expect(await liquidityProtectionStore.protectedLiquidityIds(owner.address)).to.be.empty;
+
+                        // verify stats
+                        const poolStats = await getPoolStats(poolToken, baseToken, isETH);
+                        expect(poolStats.totalPoolAmount).to.equal(
+                            prevPoolStats.totalPoolAmount.sub(protection.poolAmount)
+                        );
+                        expect(poolStats.totalReserveAmount).to.equal(
+                            prevPoolStats.totalReserveAmount.sub(protection.reserveAmount)
+                        );
+
+                        const providerStats = await getProviderStats(owner, poolToken, baseToken, isETH);
+                        expect(providerStats.totalProviderAmount).to.equal(
+                            prevProviderStats.totalProviderAmount.sub(protection.reserveAmount)
+                        );
+                        expect(providerStats.providerPools).to.deep.equal([poolToken.address]);
+
+                        // verify balances
+                        const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+                        expectInRange(systemBalance, prevSystemBalance.sub(protection.poolAmount));
+
+                        const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                        const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+                        expectInRange(vaultBaseBalance, prevVaultBaseBalance.add(protection.reserveAmount));
+                        expectInRange(
+                            vaultNetworkBalance,
+                            prevVaultNetworkBalance.add(protection.reserveAmount.div(2))
+                        );
+
+                        const walletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
+
+                        // double since system balance was also liquidated
+                        const delta = protection.poolAmount.mul(2);
+                        expectInRange(walletBalance, prevWalletBalance.sub(delta));
+
+                        const balance = await getBalance(baseToken, owner.address);
+                        expect(balance).to.equal(prevBalance.sub(transactionCost));
+
+                        const govBalance = await govToken.balanceOf(owner.address);
+                        expect(govBalance).to.equal(prevGovBalance);
+
+                        const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
+                        expect(protectionPoolBalance).to.equal(0);
+
+                        const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
+                        expect(protectionBaseBalance).to.equal(0);
+
+                        const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
+                        expect(protectionNetworkBalance).to.equal(0);
+                    });
+
+                    it('verifies that the owner can migrate system pool tokens', async () => {
+                        const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                        const protection = await getProtection(protectionId);
+
+                        const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+
+                        const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                        const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+
+                        await liquidityProtection.setTime(now + duration.seconds(1));
+
+                        const prevGovBalance = await govToken.balanceOf(owner.address);
+
+                        await liquidityProtection.migrateSystemPoolTokens([poolToken.address]);
+
+                        // verify balances
+                        const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+                        expect(systemBalance).to.equal(prevSystemBalance.sub(protection.poolAmount));
+
+                        const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                        const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+                        expect(vaultBaseBalance).to.equal(prevVaultBaseBalance.add(protection.reserveAmount.div(2)));
+                        expect(vaultNetworkBalance).to.equal(prevVaultNetworkBalance);
+
+                        const govBalance = await govToken.balanceOf(owner.address);
+                        expect(govBalance).to.equal(prevGovBalance);
+
+                        const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
+                        expect(protectionPoolBalance).to.equal(0);
+
+                        const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
+                        expect(protectionBaseBalance).to.equal(0);
+
+                        const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
+                        expect(protectionNetworkBalance).to.equal(0);
+                    });
+                });
+            }
+
+            describe('network token', () => {
+                beforeEach(async () => {
+                    await initLegacySystem(false);
+
+                    const amount = BigNumber.from(100_000);
+                    await baseToken.transfer(provider.address, amount);
+                    await baseToken.connect(provider).approve(network.address, amount);
+                    await network.connect(provider).deposit(baseToken.address, amount);
+
+                    const amount1 = BigNumber.from(5000);
+                    await baseToken.transfer(provider.address, amount1);
+                    await addProtectedLiquidity(
+                        poolToken.address,
+                        baseToken,
+                        baseToken.address,
+                        amount1,
+                        false,
+                        provider
+                    );
+
+                    const amount2 = BigNumber.from(1000);
+                    await addProtectedLiquidity(
+                        poolToken.address,
+                        networkToken,
+                        networkToken.address,
+                        amount2,
+                        false,
+                        owner
+                    );
+                });
+
+                it('verifies that the caller cannot migrate a position more than once in the same transaction', async () => {
+                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                    await liquidityProtection.setTime(now + duration.seconds(1));
+                    await expect(liquidityProtection.migratePositions([protectionId, protectionId])).to.be.revertedWith(
+                        'ERR_ACCESS_DENIED'
+                    );
+                });
+
+                it('verifies that the caller cannot migrate a position more than once in different transactions', async () => {
+                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                    await liquidityProtection.setTime(now + duration.seconds(1));
+                    await liquidityProtection.migratePositions([protectionId]);
+                    await expect(liquidityProtection.migratePositions([protectionId])).to.be.revertedWith(
+                        'ERR_ACCESS_DENIED'
+                    );
+                });
+
+                it('verifies that the caller can migrate positions', async () => {
+                    const protectionId = (await liquidityProtectionStore.protectedLiquidityIds(owner.address))[0];
+                    const protection = await getProtection(protectionId);
+
+                    const prevPoolStats = await getPoolStats(poolToken, networkToken, false);
+                    const prevProviderStats = await getProviderStats(owner, poolToken, networkToken, false);
+                    const prevSystemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+                    const prevWalletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
+                    const prevBalance = await getBalance(networkToken, owner.address);
+                    const prevGovBalance = await govToken.balanceOf(owner.address);
+
+                    const prevVaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                    const prevVaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+
+                    await liquidityProtection.setTime(now + duration.seconds(1));
+                    await liquidityProtection.migratePositions([protectionId]);
+
+                    // verify protected liquidities
+                    expect(await liquidityProtectionStore.protectedLiquidityIds(owner.address)).to.be.empty;
+
+                    // verify stats
+                    const poolStats = await getPoolStats(poolToken, networkToken, false);
+                    expect(poolStats.totalPoolAmount).to.equal(prevSystemBalance.add(protection.poolAmount));
+                    expect(poolStats.totalReserveAmount).to.equal(
+                        prevPoolStats.totalReserveAmount.sub(protection.reserveAmount)
+                    );
+
+                    const providerStats = await getProviderStats(owner, poolToken, networkToken, false);
+                    expect(providerStats.totalProviderAmount).to.equal(
+                        prevProviderStats.totalProviderAmount.sub(protection.reserveAmount)
+                    );
+                    expect(prevProviderStats.providerPools).to.deep.equal([poolToken.address]);
+
+                    // verify balances
+                    const systemBalance = await liquidityProtectionSystemStore.systemBalance(poolToken.address);
+                    expect(systemBalance).to.equal(prevSystemBalance.add(protection.poolAmount));
+
+                    const vaultBaseBalance = await getBalance(baseToken, masterVault.address);
+                    const vaultNetworkBalance = await getBalance(networkToken, masterVault.address);
+                    expect(vaultBaseBalance).to.equal(prevVaultBaseBalance);
+                    expect(vaultNetworkBalance).to.equal(prevVaultNetworkBalance);
+
+                    const walletBalance = await poolToken.balanceOf(liquidityProtectionWallet.address);
+                    expect(walletBalance).to.equal(prevWalletBalance);
+
+                    const balance = await getBalance(networkToken, owner.address);
+                    expect(balance).to.almostEqual(new Decimal(prevBalance.add(protection.reserveAmount).toString()), {
+                        maxRelativeError
+                    });
+
+                    const govBalance = await govToken.balanceOf(owner.address);
+                    expect(govBalance).to.equal(prevGovBalance);
+
+                    const protectionPoolBalance = await poolToken.balanceOf(liquidityProtection.address);
+                    expect(protectionPoolBalance).to.equal(0);
+
+                    const protectionBaseBalance = await getBalance(baseToken, liquidityProtection.address);
+                    expect(protectionBaseBalance).to.equal(0);
+
+                    const protectionNetworkBalance = await networkToken.balanceOf(liquidityProtection.address);
+                    expectInRange(protectionNetworkBalance, BigNumber.from(0));
+                });
+            });
+        };
+
+        for (const { totalSupply, reserve1Amount, reserve2Amount, maxRelativeError, maxOffset } of [
+            {
+                totalSupply: BigNumber.from(10_000_000),
+                reserve1Amount: BigNumber.from(1_000_000),
+                reserve2Amount: BigNumber.from(2_500_000),
+                maxRelativeError: new Decimal('0.000000000000000000000001'),
+                maxOffset: { negative: 0, positive: 0 }
+            },
+            {
+                totalSupply: toWei(10_000_000),
+                reserve1Amount: BigNumber.from(1_000_000),
+                reserve2Amount: BigNumber.from(2_500_000),
+                maxRelativeError: new Decimal('0.000000000000000000000001'),
+                maxOffset: { negative: 0, positive: 0 }
+            },
+            {
+                totalSupply: BigNumber.from(10_000_000),
+                reserve1Amount: toWei(1_000_000),
+                reserve2Amount: toWei(2_500_000),
+                maxRelativeError: new Decimal('0.000000000000000000000001003'),
+                maxOffset: { negative: 1, positive: 1 }
+            },
+            {
+                totalSupply: toWei(10_000_000),
+                reserve1Amount: toWei(1_000_000),
+                reserve2Amount: toWei(2_500_000),
+                maxRelativeError: new Decimal('0.000000000000000000000001'),
+                maxOffset: { negative: 1, positive: 1 }
+            }
+        ]) {
+            context(
+                `totalSupply = ${totalSupply}, reserve1Amount = ${reserve1Amount}, reserve2Amount = ${reserve2Amount}`,
+                () => {
+                    testLiquidityMigration(totalSupply, reserve1Amount, reserve2Amount, maxRelativeError, maxOffset);
+                }
+            );
         }
     });
 });


### PR DESCRIPTION
This is a minor refactoring PR that extracts liquidity migration tests to a scope of its own. It's a bit hard to review it via the diff, but this is the gist of it:

<img width="400" alt="Screenshot 2021-12-15 at 13 29 33" src="https://user-images.githubusercontent.com/2841614/146195350-b913c488-493b-4c80-8c0c-033f7f9918b1.png">

