### PR TITLE
Utilities semantic improvements

### DIFF
--- a/packages/v3/test/matchers/BigNumber.ts
+++ b/packages/v3/test/matchers/BigNumber.ts
@@ -11,11 +11,11 @@ const supportBigNumber = (Assertion: Chai.AssertionStatic, utils: Chai.ChaiUtils
     Assertion.overwriteMethod('almostEqual', overrideAlmostEqual(utils));
 };
 
-function override(name: string, utils: Chai.ChaiUtils) {
+const override = (name: string, utils: Chai.ChaiUtils) => {
     return (_super: (...args: any[]) => any) => overwriteBigNumberFunction(name, _super, utils);
-}
+};
 
-function overwriteBigNumberFunction(readableName: string, _super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) {
+const overwriteBigNumberFunction = (readableName: string, _super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) => {
     return function (this: Chai.AssertionStatic, ...args: any[]) {
         const [expected] = args;
         const actual = chaiUtils.flag(this, 'object');
@@ -35,13 +35,13 @@ function overwriteBigNumberFunction(readableName: string, _super: (...args: any[
             _super.apply(this, args);
         }
     };
-}
+};
 
-function overrideAlmostEqual(utils: Chai.ChaiUtils) {
+const overrideAlmostEqual = (utils: Chai.ChaiUtils) => {
     return (_super: (...args: never[]) => never) => overwriteBigNumberAlmostEqual(_super, utils);
-}
+};
 
-function overwriteBigNumberAlmostEqual(_super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) {
+const overwriteBigNumberAlmostEqual = (_super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) => {
     return function (this: Chai.AssertionStatic, ...args: any[]) {
         const [
             expected,
@@ -99,6 +99,6 @@ function overwriteBigNumberAlmostEqual(_super: (...args: any[]) => any, chaiUtil
             _super.apply(this, args);
         }
     };
-}
+};
 
 export default supportBigNumber;

--- a/packages/v3/test/matchers/Fraction.ts
+++ b/packages/v3/test/matchers/Fraction.ts
@@ -14,7 +14,7 @@ const override = (name: string, utils: Chai.ChaiUtils) => {
     return (_super: (...args: any[]) => any) => overwriteFractionFunction(name, _super, utils);
 };
 
-function overwriteFractionFunction(readableName: string, _super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) {
+const overwriteFractionFunction = (readableName: string, _super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) => {
     return function (this: Chai.AssertionStatic, ...args: any[]) {
         const [expected] = args;
         const actual = chaiUtils.flag(this, 'object');
@@ -43,13 +43,13 @@ function overwriteFractionFunction(readableName: string, _super: (...args: any[]
             _super.apply(this, args);
         }
     };
-}
+};
 
-function overrideAlmostEqual(utils: Chai.ChaiUtils) {
+const overrideAlmostEqual = (utils: Chai.ChaiUtils) => {
     return (_super: (...args: any[]) => any) => overwriteFractionAlmostEqual(_super, utils);
-}
+};
 
-function overwriteFractionAlmostEqual(_super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) {
+const overwriteFractionAlmostEqual = (_super: (...args: any[]) => any, chaiUtils: Chai.ChaiUtils) => {
     return function (this: Chai.AssertionStatic, ...args: any[]) {
         const [
             expected,
@@ -122,6 +122,6 @@ function overwriteFractionAlmostEqual(_super: (...args: any[]) => any, chaiUtils
             return _super.apply(this, args);
         }
     };
-}
+};
 
 export default supportFraction;


### PR DESCRIPTION
In BigNumber.ts and Fraction.ts:
1. Replace `obj` with `actual`
2. Replace `function` with `const`

This is branched off of `staking_rewards`, because the latter includes several other changes in the same files.
These other changes were applied as part of the `staking_rewards_accuracy_tests` branch and merged into this branch.
It would have been more appropriate to apply them in a separate branch and then merge to 'dev' (which would have allowed the same approach here). But as it stands now, this task is just easier done on this branch.