### PR TITLE
Remove `pragma-abicoder-v2`

### DIFF
--- a/packages/v3/contracts/helpers/TestBancorNetwork.sol
+++ b/packages/v3/contracts/helpers/TestBancorNetwork.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/v3/contracts/helpers/TestIFlashLoanRecipient.sol
+++ b/packages/v3/contracts/helpers/TestIFlashLoanRecipient.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/packages/v3/contracts/helpers/TestMasterPool.sol
+++ b/packages/v3/contracts/helpers/TestMasterPool.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { ITokenGovernance } from "@bancor/token-governance/contracts/ITokenGovernance.sol";
 

--- a/packages/v3/contracts/helpers/TestMathEx.sol
+++ b/packages/v3/contracts/helpers/TestMathEx.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { MathEx, Uint512 } from "../utility/MathEx.sol";
 import { Fraction } from "../utility/Types.sol";

--- a/packages/v3/contracts/helpers/TestPendingWithdrawals.sol
+++ b/packages/v3/contracts/helpers/TestPendingWithdrawals.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/v3/contracts/helpers/TestPoolAverageRate.sol
+++ b/packages/v3/contracts/helpers/TestPoolAverageRate.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { Fraction } from "../utility/Types.sol";
 import { PoolAverageRate, AverageRate } from "../pools/PoolAverageRate.sol";

--- a/packages/v3/contracts/helpers/TestPoolCollection.sol
+++ b/packages/v3/contracts/helpers/TestPoolCollection.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/v3/contracts/helpers/TestPoolCollectionWithdrawal.sol
+++ b/packages/v3/contracts/helpers/TestPoolCollectionWithdrawal.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { PoolCollectionWithdrawal } from "../pools/PoolCollectionWithdrawal.sol";
 

--- a/packages/v3/contracts/network/BancorNetwork.sol
+++ b/packages/v3/contracts/network/BancorNetwork.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/v3/contracts/network/PendingWithdrawals.sol
+++ b/packages/v3/contracts/network/PendingWithdrawals.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";

--- a/packages/v3/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/packages/v3/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/v3/contracts/pools/MasterPool.sol
+++ b/packages/v3/contracts/pools/MasterPool.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/packages/v3/contracts/pools/PoolAverageRate.sol
+++ b/packages/v3/contracts/pools/PoolAverageRate.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/packages/v3/contracts/pools/PoolCollection.sol
+++ b/packages/v3/contracts/pools/PoolCollection.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/packages/v3/contracts/pools/PoolCollectionUpgrader.sol
+++ b/packages/v3/contracts/pools/PoolCollectionUpgrader.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IBancorNetwork } from "../network/interfaces/IBancorNetwork.sol";
 

--- a/packages/v3/contracts/pools/interfaces/IMasterPool.sol
+++ b/packages/v3/contracts/pools/interfaces/IMasterPool.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/v3/contracts/pools/interfaces/IPoolCollection.sol
+++ b/packages/v3/contracts/pools/interfaces/IPoolCollection.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/packages/v3/contracts/pools/interfaces/IPoolCollectionUpgrader.sol
+++ b/packages/v3/contracts/pools/interfaces/IPoolCollectionUpgrader.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
-pragma abicoder v2;
 
 import { IBancorNetwork } from "../../network/interfaces/IBancorNetwork.sol";
 


### PR DESCRIPTION
Since abicoder v2 is activated by default starting from Solidity 0.8.0, there is no need to explicitly state it (while the option to select the old coder using `pragma abicoder v1` is still viable).

See https://docs.soliditylang.org/en/v0.8.0/layout-of-source-files.html#abi-coder-pragma.