### PR TITLE
Compress Average Rate

### DIFF
--- a/packages/v3/contracts/helpers/TestPoolAverageRate.sol
+++ b/packages/v3/contracts/helpers/TestPoolAverageRate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.10;
 
-import { Fraction } from "../utility/Types.sol";
+import { Fraction, Fraction112 } from "../utility/Types.sol";
 import { PoolAverageRate, AverageRate } from "../pools/PoolAverageRate.sol";
 
 contract TestPoolAverageRate {
@@ -21,7 +21,7 @@ contract TestPoolAverageRate {
         return PoolAverageRate.isPoolRateStable(spotRate, averageRate, maxDeviation);
     }
 
-    function reducedRatio(Fraction memory ratio) external pure returns (Fraction memory) {
+    function reducedRatio(Fraction memory ratio) external pure returns (Fraction112 memory) {
         return PoolAverageRate.reducedRatio(ratio);
     }
 

--- a/packages/v3/contracts/pools/PoolAverageRate.sol
+++ b/packages/v3/contracts/pools/PoolAverageRate.sol
@@ -5,11 +5,11 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { MathEx } from "../utility/MathEx.sol";
 import { PPM_RESOLUTION } from "../utility/Constants.sol";
-import { Fraction, Uint512 } from "../utility/Types.sol";
+import { Fraction, Fraction112, Uint512 } from "../utility/Types.sol";
 
 struct AverageRate {
     uint32 time; // the time when the rate was recorded (Unix timestamp))
-    Fraction rate; // the rate
+    Fraction112 rate; // the rate
 }
 
 /**
@@ -110,15 +110,15 @@ library PoolAverageRate {
     /**
      * @dev reduces the components of a given ratio to 112 bits
      */
-    function reducedRatio(Fraction memory ratio) internal pure returns (Fraction memory) {
+    function reducedRatio(Fraction memory ratio) internal pure returns (Fraction112 memory) {
         uint256 scale = Math.ceilDiv(Math.max(ratio.n, ratio.d), type(uint112).max);
-        return Fraction({ n: ratio.n / scale, d: ratio.d / scale });
+        return Fraction112({ n: uint112(ratio.n / scale), d: uint112(ratio.d / scale) });
     }
 
     /**
      * @dev compares two average rates
      */
     function isEqual(AverageRate memory averageRate1, AverageRate memory averageRate2) internal pure returns (bool) {
-        return averageRate1.rate.n * averageRate2.rate.d == averageRate2.rate.n * averageRate1.rate.d;
+        return uint256(averageRate1.rate.n) * averageRate2.rate.d == uint256(averageRate2.rate.n) * averageRate1.rate.d;
     }
 }

--- a/packages/v3/contracts/utility/Types.sol
+++ b/packages/v3/contracts/utility/Types.sol
@@ -10,6 +10,11 @@ struct Fraction {
     uint256 d; // denominator
 }
 
+struct Fraction112 {
+    uint112 n; // numerator
+    uint112 d; // denominator
+}
+
 struct Uint512 {
     uint256 hi; // 256 most significant bits
     uint256 lo; // 256 least significant bits


### PR DESCRIPTION
This PR includes the following changes:
1. Reduce the size of the average rate in storage from 544 bits (3 slots) to 256 bits (1 slot).
2. `PoolCollection.depositFor`: if we're using the initial rate, then save a reduced copy of it as the average rate.

A few notes on the 2nd bullet:
1. There is no need to check in advance if the two rates happen to be equal, as it doesn't really save gas or anything.
2. Prior to this change, the average rate is 112x112 bits everywhere except here. So even though the accuracy of the average rate is degraded following this change, it is probably better to keep it consistent across the system.

A note about the possible change from SMA to EMA:

Following this change, the average-rate timestamp might become redundant (depending on our 'first trade in the block' strategy).

Under that scenario, we will be able to increase the accuracy of the average rate from this:
```
struct AverageRate {
    uint32 time;
    Fraction112 rate;
}
```
To this:
```
struct AverageRate {
    Fraction128 rate;
}
```
Applying this change should be pretty easy.