### PR TITLE
Add deployment-only coverage task

### DIFF
--- a/packages/v3/package.json
+++ b/packages/v3/package.json
@@ -25,6 +25,7 @@
         "test": "NODE_OPTIONS=\"--max-old-space-size=30000 ${CI:+--openssl-legacy-provider}\" hardhat test",
         "testb": "BAIL=1 yarn test",
         "test:coverage": "yarn build && NODE_OPTIONS=${CI:+'--max-old-space-size=30000 --openssl-legacy-provider'} hardhat coverage",
+        "test:coverage:deploy": "yarn test:coverage --testfiles 'test/deployment/**/*.ts'",
         "test:ci": "CI=1 yarn test",
         "test:deploy": "mocha --require hardhat/register --extension ts --recursive --exit --timeout 600000 'test/deployment/**/*.ts'",
         "test:deploy:mainnet": "HARDHAT_NETWORK=hardhat FORKING=1 yarn test:deploy",


### PR DESCRIPTION
The goal of the new test:coverage:deploy task would be to perform test coverage checks *only* on deployment-related tasks, this giving us a good insight what is being covered by the deployment e2e check