### PR TITLE
Fix the ERC20 errors in the tests

### DIFF
--- a/test/bancor-portal/BancorPortal.ts
+++ b/test/bancor-portal/BancorPortal.ts
@@ -113,7 +113,7 @@ describe('BancorPortal', () => {
             await uniswapV2Factory.setTokens(token1.address, token2.address);
             await expect(
                 bancorPortal.connect(user).migrateUniswapV2Position(token1.address, token2.address, 10)
-            ).to.be.revertedWith('ERC20: insufficient allowance');
+            ).to.be.revertedWith(new TokenData(TokenSymbol.TKN1).errors().exceedsAllowance);
         });
 
         it('reverts if the input amount is 0', async () => {

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2837,7 +2837,7 @@ describe('BancorNetwork', () => {
             it('should revert when attempting to request a flash-loan of more than the pool has', async () => {
                 await expect(
                     network.flashLoan(token.address, BALANCE.add(1), recipient.address, ZERO_BYTES)
-                ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
+                ).to.be.revertedWith(new TokenData(TokenSymbol.TKN).errors().exceedsBalance);
             });
 
             context('when paused', () => {

--- a/test/network/PendingWithdrawals.ts
+++ b/test/network/PendingWithdrawals.ts
@@ -278,14 +278,14 @@ describe('PendingWithdrawals', () => {
                     it('should revert when attempting to withdraw an invalid amount of pool tokens', async () => {
                         await expect(
                             network.connect(provider).initWithdrawal(poolToken.address, poolTokenAmount.add(1))
-                        ).to.be.revertedWith('ERC20: insufficient allowance');
+                        ).to.be.revertedWith(new TokenData(TokenSymbol.TKN).errors().exceedsBalance);
                     });
 
                     it('should revert when attempting to withdraw an insufficient amount of pool tokens', async () => {
                         const providerBalance = await poolToken.balanceOf(providerAddress);
                         await expect(
                             network.connect(provider).initWithdrawal(poolToken.address, providerBalance.add(1))
-                        ).to.be.revertedWith('ERC20: insufficient allowance');
+                        ).to.be.revertedWith(new TokenData(TokenSymbol.TKN).errors().exceedsBalance);
                     });
 
                     it('should init a withdraw', async () => {

--- a/test/pools/BNTPool.ts
+++ b/test/pools/BNTPool.ts
@@ -690,7 +690,7 @@ describe('BNTPool', () => {
 
                     await expect(
                         network.depositToBNTPoolForT(CONTEXT_ID, provider.address, maxAmount.add(1), false, 0)
-                    ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
+                    ).to.be.revertedWith(new TokenData(TokenSymbol.TKN).errors().exceedsBalance);
                 });
 
                 it('should allow depositing liquidity', async () => {
@@ -868,7 +868,7 @@ describe('BNTPool', () => {
 
                         await expect(
                             network.withdrawFromBNTPoolT(CONTEXT_ID, provider.address, poolTokenAmount)
-                        ).to.be.revertedWith('ERC20: transfer amount exceeds balance');
+                        ).to.be.revertedWith(new TokenData(TokenSymbol.TKN).errors().exceedsBalance);
                     });
 
                     it('should revert when attempting to deposit without sending VBNT', async () => {
@@ -888,7 +888,7 @@ describe('BNTPool', () => {
 
                         await expect(
                             network.withdrawFromBNTPoolT(CONTEXT_ID, provider.address, poolTokenAmount)
-                        ).to.be.revertedWith('ERC20: insufficient allowance');
+                        ).to.be.revertedWith(new TokenData(TokenSymbol.BNT).errors().exceedsAllowance);
                     });
 
                     it('should allow withdrawing liquidity', async () => {

--- a/test/token/ERC20Burnable.ts
+++ b/test/token/ERC20Burnable.ts
@@ -1,5 +1,6 @@
 import Contracts, { TestERC20Burnable } from '../../components/Contracts';
 import { ZERO_ADDRESS } from '../../utils/Constants';
+import { TokenData, TokenSymbol } from '../../utils/TokenData';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { BigNumber, ContractTransaction } from 'ethers';
@@ -52,7 +53,7 @@ describe('ERC20Burnable', () => {
             const initialBalance = await burnable.balanceOf(owner.address);
 
             await expect(burnable.connect(owner).burn(initialBalance.add(1))).to.be.revertedWith(
-                'ERC20: burn amount exceeds balance'
+                new TokenData(TokenSymbol.TKN).errors().burnExceedsBalance
             );
         });
     });

--- a/utils/TokenData.ts
+++ b/utils/TokenData.ts
@@ -54,7 +54,7 @@ const TOKEN_DATA = {
         name: 'Test Token',
         decimals: DEFAULT_DECIMALS,
         errors: {
-            exceedsAllowance: 'ERC20: insufficient allowance',
+            exceedsAllowance: 'ERC20: transfer amount exceeds allowance',
             exceedsBalance: 'ERC20: transfer amount exceeds balance',
             burnExceedsBalance: 'ERC20: burn amount exceeds balance'
         }
@@ -63,7 +63,7 @@ const TOKEN_DATA = {
         name: 'Test Token 1',
         decimals: DEFAULT_DECIMALS,
         errors: {
-            exceedsAllowance: 'ERC20: insufficient allowance',
+            exceedsAllowance: 'ERC20: transfer amount exceeds allowance',
             exceedsBalance: 'ERC20: transfer amount exceeds balance',
             burnExceedsBalance: 'ERC20: burn amount exceeds balance'
         }
@@ -72,7 +72,7 @@ const TOKEN_DATA = {
         name: 'Test Token 2',
         decimals: DEFAULT_DECIMALS,
         errors: {
-            exceedsAllowance: 'ERC20: insufficient allowance',
+            exceedsAllowance: 'ERC20: transfer amount exceeds allowance',
             exceedsBalance: 'ERC20: transfer amount exceeds balance',
             burnExceedsBalance: 'ERC20: burn amount exceeds balance'
         }


### PR DESCRIPTION
This PR includes:
- Update the definition of ERC20 errors in the tests
- Fix the handling of ERC20 errors in the tests

We might also want to do the following cosmetic changes (though in a separate PR, in order to avoid confusion):
- Rename `exceedsAllowance` to `transferExceedsAllowance`
- Rename `exceedsBalance` to `transferExceedsBalance`

This is in order to align these two symbols with `burnExceedsBalance`.