### PR TITLE
Fix the 'reset-liquidity' logic

### DIFF
--- a/contracts/pools/PoolCollection.sol
+++ b/contracts/pools/PoolCollection.sol
@@ -603,7 +603,14 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuard, BlockNumber,
         data.poolToken.mint(provider, poolTokenAmount);
 
         // adjust the trading liquidity based on the base token vault balance and funding limits
-        _updateTradingLiquidity(contextId, pool, data, data.liquidity, _networkSettings.minLiquidityForTrading());
+        _updateTradingLiquidity(
+            contextId,
+            pool,
+            data,
+            data.liquidity,
+            data.averageRate.rate.fromFraction112(),
+            _networkSettings.minLiquidityForTrading()
+        );
 
         emit TokenDeposited({
             contextId: contextId,
@@ -1092,33 +1099,6 @@ contract PoolCollection is IPoolCollection, Owned, ReentrancyGuard, BlockNumber,
         }
 
         return TradingLiquidityAction({ update: true, newAmount: targetBNTTradingLiquidity });
-    }
-
-    /**
-     * @dev adjusts the trading liquidity based on the base token vault balance and funding limits
-     */
-    function _updateTradingLiquidity(
-        bytes32 contextId,
-        Token pool,
-        Pool storage data,
-        PoolLiquidity memory liquidity,
-        uint256 minLiquidityForTrading
-    ) private {
-        // ensure that the BNT trading liquidity is above the minimum liquidity for trading
-        if (liquidity.bntTradingLiquidity < minLiquidityForTrading) {
-            _resetTradingLiquidity(contextId, pool, data, TRADING_STATUS_UPDATE_MIN_LIQUIDITY);
-
-            return;
-        }
-
-        _updateTradingLiquidity(
-            contextId,
-            pool,
-            data,
-            liquidity,
-            data.averageRate.rate.fromFraction112(),
-            minLiquidityForTrading
-        );
     }
 
     /**


### PR DESCRIPTION
Instead of resetting the liquidity when it's below the minimum threshold, reset it if the calculation of the new liquidity returns a value below the minimum threshold.