### PR TITLE
Ensure `onlyInitializing` in the upgradability infrastructure

### DIFF
--- a/contracts/bancor-portal/BancorPortal.sol
+++ b/contracts/bancor-portal/BancorPortal.sol
@@ -130,7 +130,7 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
     /**
      * @dev initializes the contract and its parents
      */
-    function __BancorPortal_init() internal initializer {
+    function __BancorPortal_init() internal onlyInitializing {
         __ReentrancyGuard_init();
         __Upgradeable_init();
 
@@ -140,7 +140,7 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
     /**
      * @dev performs contract-specific initialization
      */
-    function __BancorPortal_init_unchained() internal initializer {}
+    function __BancorPortal_init_unchained() internal onlyInitializing {}
 
     /**
      * @dev ETH receive callback

--- a/contracts/staking-rewards/AutoCompoundingStakingRewards.sol
+++ b/contracts/staking-rewards/AutoCompoundingStakingRewards.sol
@@ -140,7 +140,7 @@ contract AutoCompoundingStakingRewards is
     /**
      * @dev initializes the contract and its parents
      */
-    function __AutoCompoundingStakingRewards_init() internal initializer {
+    function __AutoCompoundingStakingRewards_init() internal onlyInitializing {
         __ReentrancyGuard_init();
         __Upgradeable_init();
 
@@ -150,7 +150,7 @@ contract AutoCompoundingStakingRewards is
     /**
      * @dev performs contract-specific initialization
      */
-    function __AutoCompoundingStakingRewards_init_unchained() internal initializer {}
+    function __AutoCompoundingStakingRewards_init_unchained() internal onlyInitializing {}
 
     // solhint-enable func-name-mixedcase
 

--- a/contracts/staking-rewards/StandardStakingRewards.sol
+++ b/contracts/staking-rewards/StandardStakingRewards.sol
@@ -211,7 +211,7 @@ contract StandardStakingRewards is IStandardStakingRewards, ReentrancyGuardUpgra
     /**
      * @dev initializes the contract and its parents
      */
-    function __StandardStakingRewards_init() internal initializer {
+    function __StandardStakingRewards_init() internal onlyInitializing {
         __ReentrancyGuard_init();
         __Upgradeable_init();
 
@@ -221,7 +221,7 @@ contract StandardStakingRewards is IStandardStakingRewards, ReentrancyGuardUpgra
     /**
      * @dev performs contract-specific initialization
      */
-    function __StandardStakingRewards_init_unchained() internal initializer {
+    function __StandardStakingRewards_init_unchained() internal onlyInitializing {
         _nextProgramId = INITIAL_PROGRAM_ID;
     }
 


### PR DESCRIPTION
Ensure `onlyInitializing` in the internal implementation of the upgradability infrastructure in the following contracts:
1. `BancorPortal`
2. `AutoCompoundingStakingRewards`
3. `StandardStakingRewards`
