### PR TITLE
Add `depositedA` and `depositedB` in the `BancorPortal` migration events

### DIFF
--- a/contracts/bancor-portal/BancorPortal.sol
+++ b/contracts/bancor-portal/BancorPortal.sol
@@ -20,7 +20,16 @@ import { INetworkSettings } from "../network/interfaces/INetworkSettings.sol";
 import { NetworkSettings } from "../network/NetworkSettings.sol";
 import { IPoolToken } from "../pools/interfaces/IPoolToken.sol";
 
-import { IBancorPortal, MigrationResult, UniswapV2PositionMigration } from "./interfaces/IBancorPortal.sol";
+import { IBancorPortal, UniswapV2PositionMigration } from "./interfaces/IBancorPortal.sol";
+
+struct MigrationResult {
+    Token tokenA;
+    Token tokenB;
+    uint256 amountA;
+    uint256 amountB;
+    bool depositedA;
+    bool depositedB;
+}
 
 /**
  * @dev one click liquidity migration between other DEXes into Bancor v3
@@ -65,7 +74,9 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
         Token indexed tokenA,
         Token indexed tokenB,
         uint256 amountA,
-        uint256 amountB
+        uint256 amountB,
+        bool depositedA,
+        bool depositedB
     );
 
     /**
@@ -76,7 +87,9 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
         Token indexed tokenA,
         Token indexed tokenB,
         uint256 amountA,
-        uint256 amountB
+        uint256 amountB,
+        bool depositedA,
+        bool depositedB
     );
 
     error UnsupportedTokens();
@@ -176,7 +189,9 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
             tokenA: res.tokenA,
             tokenB: res.tokenB,
             amountA: res.amountA,
-            amountB: res.amountB
+            amountB: res.amountB,
+            depositedA: res.depositedA,
+            depositedB: res.depositedB
         });
 
         return UniswapV2PositionMigration({ amountA: res.amountA, amountB: res.amountB });
@@ -211,7 +226,9 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
             tokenA: res.tokenA,
             tokenB: res.tokenB,
             amountA: res.amountA,
-            amountB: res.amountB
+            amountB: res.amountB,
+            depositedA: res.depositedA,
+            depositedB: res.depositedB
         });
 
         return UniswapV2PositionMigration({ amountA: res.amountA, amountB: res.amountB });
@@ -274,7 +291,15 @@ contract BancorPortal is IBancorPortal, ReentrancyGuardUpgradeable, Utils, Upgra
             }
         }
 
-        return MigrationResult({ tokenA: tokens[0], tokenB: tokens[1], amountA: deposited[0], amountB: deposited[1] });
+        return
+            MigrationResult({
+                tokenA: tokens[0],
+                tokenB: tokens[1],
+                amountA: deposited[0],
+                amountB: deposited[1],
+                depositedA: whitelist[0],
+                depositedB: whitelist[1]
+            });
     }
 
     /**

--- a/contracts/bancor-portal/interfaces/IBancorPortal.sol
+++ b/contracts/bancor-portal/interfaces/IBancorPortal.sol
@@ -5,13 +5,6 @@ import { IUpgradeable } from "../../utility/interfaces/IUpgradeable.sol";
 import { INetworkSettings } from "../../network/interfaces/INetworkSettings.sol";
 import { Token } from "../../token/Token.sol";
 
-struct MigrationResult {
-    Token tokenA;
-    Token tokenB;
-    uint256 amountA;
-    uint256 amountB;
-}
-
 struct UniswapV2PositionMigration {
     uint256 amountA;
     uint256 amountB;

--- a/test/bancor-portal/BancorPortal.ts
+++ b/test/bancor-portal/BancorPortal.ts
@@ -147,7 +147,15 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken1.address, whitelistedToken2.address, AMOUNT, AMOUNT);
+                .withArgs(
+                    user.address,
+                    whitelistedToken1.address,
+                    whitelistedToken2.address,
+                    AMOUNT,
+                    AMOUNT,
+                    true,
+                    true
+                );
         });
     });
 
@@ -309,7 +317,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO);
+                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO, true, false);
         });
 
         it('deposits when only token2 is whitelisted', async () => {
@@ -323,7 +331,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, unlistedToken.address, whitelistedToken.address, ZERO, AMOUNT);
+                .withArgs(user.address, unlistedToken.address, whitelistedToken.address, ZERO, AMOUNT, false, true);
         });
 
         it('deposits both tokens when possible', async () => {
@@ -337,7 +345,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, token1.address, token2.address, AMOUNT, AMOUNT);
+                .withArgs(user.address, token1.address, token2.address, AMOUNT, AMOUNT, true, true);
         });
 
         it('deposits when token1 is the native token and token2 is unlisted', async () => {
@@ -351,7 +359,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO);
+                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO, true, false);
         });
 
         it('deposits when token1 is the native token and token2 is whitelisted', async () => {
@@ -365,7 +373,15 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken1.address, whitelistedToken2.address, AMOUNT, AMOUNT);
+                .withArgs(
+                    user.address,
+                    whitelistedToken1.address,
+                    whitelistedToken2.address,
+                    AMOUNT,
+                    AMOUNT,
+                    true,
+                    true
+                );
         });
 
         it('deposits when token1 is unlisted and token2 is the native token', async () => {
@@ -379,7 +395,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, unlistedToken.address, whitelistedToken.address, ZERO, AMOUNT);
+                .withArgs(user.address, unlistedToken.address, whitelistedToken.address, ZERO, AMOUNT, false, true);
         });
 
         it('deposits when token1 is whitelisted and token2 is the native token', async () => {
@@ -393,7 +409,15 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken1.address, whitelistedToken2.address, AMOUNT, AMOUNT);
+                .withArgs(
+                    user.address,
+                    whitelistedToken1.address,
+                    whitelistedToken2.address,
+                    AMOUNT,
+                    AMOUNT,
+                    true,
+                    true
+                );
         });
 
         it('deposits when token1 is bnt and token2 is unlisted', async () => {
@@ -409,7 +433,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, bnt.address, unlistedToken.address, AMOUNT, ZERO);
+                .withArgs(user.address, bnt.address, unlistedToken.address, AMOUNT, ZERO, true, false);
         });
 
         it('deposits when token1 is unlisted and token2 is bnt', async () => {
@@ -425,7 +449,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, unlistedToken.address, bnt.address, ZERO, AMOUNT);
+                .withArgs(user.address, unlistedToken.address, bnt.address, ZERO, AMOUNT, false, true);
         });
 
         it('deposits when token1 is bnt and token2 is whitelisted', async () => {
@@ -440,7 +464,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, bnt.address, whitelistedToken.address, AMOUNT, AMOUNT);
+                .withArgs(user.address, bnt.address, whitelistedToken.address, AMOUNT, AMOUNT, true, true);
         });
 
         it('deposits when token1 is whitelisted and token2 is bnt', async () => {
@@ -455,7 +479,7 @@ describe('BancorPortal', () => {
             ]);
             expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken.address, bnt.address, AMOUNT, AMOUNT);
+                .withArgs(user.address, whitelistedToken.address, bnt.address, AMOUNT, AMOUNT, true, true);
         });
     });
 
@@ -477,7 +501,7 @@ describe('BancorPortal', () => {
             );
             expect(res)
                 .to.emit(bancorPortal, 'SushiSwapV2PositionMigrated')
-                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO);
+                .withArgs(user.address, whitelistedToken.address, unlistedToken.address, AMOUNT, ZERO, true, false);
         });
     });
 


### PR DESCRIPTION
I've also moved the `MigrationResult` structure from the interface to the contract, because it is used only internally in that contract.