### PR TITLE
Fix the `BancorNetworkInfo` contract

### DIFF
--- a/contracts/network/BancorNetworkInfo.sol
+++ b/contracts/network/BancorNetworkInfo.sol
@@ -240,7 +240,7 @@ contract BancorNetworkInfo is IBancorNetworkInfo, Upgradeable, Utils {
     /**
      * @inheritdoc IBancorNetworkInfo
      */
-    function poolToken(Token pool) external view returns (IPoolToken) {
+    function poolTokenOf(Token pool) external view returns (IPoolToken) {
         return _isBNT(pool) ? _bntPoolToken : _poolCollection(pool).poolToken(pool);
     }
 
@@ -310,18 +310,19 @@ contract BancorNetworkInfo is IBancorNetworkInfo, Upgradeable, Utils {
     /**
      * @inheritdoc IBancorNetworkInfo
      */
-    function withdrawalAmounts(Token pool, uint256 poolTokenAmount)
+    function withdrawalAmounts(IPoolToken poolToken, uint256 poolTokenAmount)
         external
         view
-        validAddress(address(pool))
+        validAddress(address(poolToken))
         greaterThanZero(poolTokenAmount)
         returns (WithdrawalAmounts memory)
     {
-        if (_isBNT(pool)) {
+        if (poolToken == _bntPoolToken) {
             uint256 amount = _bntPool.withdrawalAmount(poolTokenAmount);
             return WithdrawalAmounts({ totalAmount: amount, baseTokenAmount: 0, bntAmount: amount });
         }
 
+        Token pool = poolToken.reserveToken();
         IPoolCollection poolCollection = _poolCollection(pool);
         return poolCollection.withdrawalAmounts(pool, poolTokenAmount);
     }

--- a/contracts/network/interfaces/IBancorNetworkInfo.sol
+++ b/contracts/network/interfaces/IBancorNetworkInfo.sol
@@ -80,7 +80,7 @@ interface IBancorNetworkInfo is IUpgradeable {
     /**
      * @dev returns the pool token contract for a given pool
      */
-    function poolToken(Token pool) external view returns (IPoolToken);
+    function poolTokenOf(Token pool) external view returns (IPoolToken);
 
     /**
      * @dev returns the pending withdrawals contract
@@ -129,5 +129,5 @@ interface IBancorNetworkInfo is IUpgradeable {
      * @dev returns the amounts that would be returned if the position is currently withdrawn,
      * along with the breakdown of the base token and the BNT compensation
      */
-    function withdrawalAmounts(Token pool, uint256 poolTokenAmount) external view returns (WithdrawalAmounts memory);
+    function withdrawalAmounts(IPoolToken poolToken, uint256 poolTokenAmount) external view returns (WithdrawalAmounts memory);
 }

--- a/test/deployment/1642682507-network-info.ts
+++ b/test/deployment/1642682507-network-info.ts
@@ -74,7 +74,7 @@ describeDeployment('1642682507-network-info', ContractName.BancorNetworkInfoV1, 
         expect(await networkInfo.externalProtectionVault()).to.equal(externalProtectionVault.address);
         expect(await networkInfo.externalRewardsVault()).to.equal(externalRewardsVault.address);
         expect(await networkInfo.bntPool()).to.equal(bntPool.address);
-        expect(await networkInfo.poolToken(bnt.address)).to.equal(bntPoolToken.address);
+        expect(await networkInfo.poolTokenOf(bnt.address)).to.equal(bntPoolToken.address);
         expect(await networkInfo.pendingWithdrawals()).to.equal(pendingWithdrawals.address);
         expect(await networkInfo.poolCollectionUpgrader()).to.equal(poolCollectionUpgrader.address);
 

--- a/test/helpers/Factory.ts
+++ b/test/helpers/Factory.ts
@@ -440,7 +440,7 @@ const setupPool = async (
     const bnt = await factory.attach(await networkInfo.bnt());
 
     if (spec.token?.address === bnt.address || spec.tokenData.isBNT()) {
-        const poolToken = await Contracts.PoolToken.attach(await networkInfo.poolToken(bnt.address));
+        const poolToken = await Contracts.PoolToken.attach(await networkInfo.poolTokenOf(bnt.address));
 
         // ensure that there is enough space to deposit BNT
         const reserveToken = await createTestToken();

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -1718,7 +1718,7 @@ describe('BancorNetwork', () => {
 
                     if (tokenData.isBNT()) {
                         const { totalAmount, baseTokenAmount, bntAmount } = await networkInfo.withdrawalAmounts(
-                            bnt.address,
+                            bntPoolToken.address,
                             request.poolTokenAmount
                         );
                         await network.connect(provider).withdraw(request.id);
@@ -1740,7 +1740,7 @@ describe('BancorNetwork', () => {
                         );
                     } else {
                         const { totalAmount, baseTokenAmount, bntAmount } = await networkInfo.withdrawalAmounts(
-                            token.address,
+                            poolToken.address,
                             request.poolTokenAmount
                         );
                         const res = await network.connect(provider).withdraw(request.id);

--- a/test/network/BancorNetworkInfo.ts
+++ b/test/network/BancorNetworkInfo.ts
@@ -279,7 +279,7 @@ describe('BancorNetworkInfo', () => {
             expect(await networkInfo.externalProtectionVault()).to.equal(externalProtectionVault.address);
             expect(await networkInfo.externalRewardsVault()).to.equal(externalRewardsVault.address);
             expect(await networkInfo.bntPool()).to.equal(bntPool.address);
-            expect(await networkInfo.poolToken(bnt.address)).to.equal(bntPoolToken.address);
+            expect(await networkInfo.poolTokenOf(bnt.address)).to.equal(bntPoolToken.address);
             expect(await networkInfo.pendingWithdrawals()).to.equal(pendingWithdrawals.address);
             expect(await networkInfo.poolCollectionUpgrader()).to.equal(poolCollectionUpgrader.address);
         });
@@ -513,7 +513,6 @@ describe('BancorNetworkInfo', () => {
 
     describe('pending withdrawals', () => {
         let poolToken: PoolToken;
-        let token: TokenWithAddress;
         let networkInfo: BancorNetworkInfo;
         let networkSettings: NetworkSettings;
         let network: TestBancorNetwork;
@@ -536,7 +535,7 @@ describe('BancorNetworkInfo', () => {
 
             await pendingWithdrawals.setTime(await latest());
 
-            ({ poolToken, token } = await setupFundedPool(
+            ({ poolToken } = await setupFundedPool(
                 {
                     tokenData: new TokenData(TokenSymbol.TKN),
                     balance: BALANCE,
@@ -577,12 +576,12 @@ describe('BancorNetworkInfo', () => {
         });
 
         it('should not return withdrawal amounts when the pool token amount is zero', async () => {
-            await expect(networkInfo.withdrawalAmounts(token.address, 0)).to.be.revertedWith('ZeroValue');
+            await expect(networkInfo.withdrawalAmounts(poolToken.address, 0)).to.be.revertedWith('ZeroValue');
         });
 
         it('should return withdrawal amounts', async () => {
             const { totalAmount, baseTokenAmount, bntAmount } = await networkInfo.withdrawalAmounts(
-                token.address,
+                poolToken.address,
                 poolTokenAmount
             );
             expect(totalAmount).to.equal(poolTokenAmount);
@@ -647,8 +646,8 @@ describe('BancorNetworkInfo', () => {
             });
 
             it('should return the pool token correctly', async () => {
-                expect(await networkInfo.poolToken(bnt.address)).to.equal(await bntPool.poolToken());
-                expect(await networkInfo.poolToken(reserveToken.address)).to.equal(
+                expect(await networkInfo.poolTokenOf(bnt.address)).to.equal(await bntPool.poolToken());
+                expect(await networkInfo.poolTokenOf(reserveToken.address)).to.equal(
                     await poolCollection.poolToken(reserveToken.address)
                 );
             });


### PR DESCRIPTION
In the `BancorNetworkInfo` contract:
1. Rename function `poolToken` to `poolTokenOf`.
2. Change function `withdrawalAmounts` input from `Token` to `IPoolToken`.
