### PR TITLE
Extend base-token withdrawal coverage

### DIFF
--- a/test/pools/PoolCollection.ts
+++ b/test/pools/PoolCollection.ts
@@ -1923,6 +1923,21 @@ describe('PoolCollection', () => {
                     toPPM(1)
                 );
             });
+
+            it('BNT - renounce funding, burn from MV; TKN - transfer from MV and from EPV to provider', async () => {
+                await testWithdrawalPermutations(
+                    new TokenData(TokenSymbol.TKN),
+                    toWei(1).div(10),
+                    toWei(1000),
+                    toWei(1000),
+                    toWei(1000),
+                    toWei(1000),
+                    toWei(1000),
+                    toWei(1000),
+                    toPPM(1),
+                    toPPM(1)
+                );
+            });
         });
 
         for (const symbol of [TokenSymbol.ETH, TokenSymbol.TKN]) {


### PR DESCRIPTION
1. Refactor mocha stuff ('before', 'it', etc) out of the `testWithdrawalPermutations` function
2. Add quick tests (based on this method) for covering the following withdrawal aspects:
   2.1. BNT - renounce funding, burn from MV, mint for provider; TKN - transfer from MV and from EPV to provider
   2.2. BNT - mint for MV; TKN - transfer from EPV to provider

In addition to the above, ensure the coverage of a branch in function `PoolCollectionWithdrawal.externalProtection`.