### PR TITLE
Add a safety-check when removing a pool collection

### DIFF
--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -23,6 +23,7 @@ import {
     DoesNotExist,
     InvalidToken,
     InvalidType,
+    InvalidPoolCollection,
     NotEmpty
 } from "../utility/Utils.sol";
 
@@ -365,6 +366,10 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         onlyAdmin
         nonReentrant
     {
+        if (poolCollection == newLatestPoolCollection) {
+            revert InvalidPoolCollection();
+        }
+
         // verify that a pool collection is a valid latest pool collection (e.g., it either exists or a reset to zero)
         _verifyLatestPoolCollectionCandidate(newLatestPoolCollection);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -697,6 +697,12 @@ describe('BancorNetwork', () => {
                     ).to.be.revertedWith('DoesNotExist');
                 });
 
+                it('should revert when attempting to remove a pool collection and specifying it as the latest', async () => {
+                    await expect(
+                        network.removePoolCollection(poolCollection.address, poolCollection.address)
+                    ).to.be.revertedWith('InvalidPoolCollection');
+                });
+
                 it('should remove an existing pool collection', async () => {
                     expect(await network.poolCollections()).to.have.members([
                         poolCollection.address,


### PR DESCRIPTION
Function `BancorNetwork.removePoolCollection`: revert when attempting to remove a pool collection and specifying it as the latest.