### PR TITLE
Ensure that TokensTraded event is fired only once + make trading flow more intuitive

### DIFF
--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -1170,7 +1170,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
                 targetAmount: lastHopTradeResult.targetAmount,
                 bntAmount: fromBNT ? lastHopTradeResult.sourceAmount : lastHopTradeResult.targetAmount,
                 targetFeeAmount: lastHopTradeResult.tradingFeeAmount,
-                bntFeeAmount: fromBNT ? lastHopTradeResult.networkFeeAmount : lastHopTradeResult.tradingFeeAmount,
+                bntFeeAmount: fromBNT ? 0 : lastHopTradeResult.tradingFeeAmount,
                 trader: traderInfo.trader
             });
         } else {

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2429,7 +2429,7 @@ describe('BancorNetwork', () => {
                         targetAmount,
                         sourceAmount,
                         hop2.tradingFeeAmount,
-                        hop2.networkFeeAmount,
+                        0,
                         traderAddress
                     );
             } else if (isTargetBNT) {


### PR DESCRIPTION
The main thing to note: previously, the "intermediate" trade functions returned the resulting amount, which had a different meaning if we're trading via the source amount (and then it's the received target amount) or via the target amount and then it's the required source amount) and it made everything pretty confusing. In this PR, I've changed so that every function returns both the source and the target amount (regardless of the input), so everything is much more intuitive about ~3k gas for double-hop trades.

This also saves about ~3k gas for double-hop trades.