### PR TITLE
Add Return Values to Different BancorNetwork Methods for Simplified Integrations

### DIFF
--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -836,18 +836,21 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint256 amount,
         uint256 availableAmount,
         uint256 originalAmount
-    ) external payable whenNotPaused onlyRoleMember(ROLE_MIGRATION_MANAGER) nonReentrant {
+    ) external payable whenNotPaused onlyRoleMember(ROLE_MIGRATION_MANAGER) nonReentrant returns (uint256) {
         bytes32 contextId = keccak256(
             abi.encodePacked(msg.sender, _time(), token, provider, amount, availableAmount, originalAmount)
         );
 
+        uint256 poolTokenAmount;
         if (token.isEqual(_bnt)) {
-            _depositBNTFor(contextId, provider, amount, msg.sender, true, originalAmount);
+            poolTokenAmount = _depositBNTFor(contextId, provider, amount, msg.sender, true, originalAmount);
         } else {
-            _depositBaseTokenFor(contextId, provider, token, amount, msg.sender, availableAmount);
+            poolTokenAmount = _depositBaseTokenFor(contextId, provider, token, amount, msg.sender, availableAmount);
         }
 
         emit FundsMigrated(contextId, token, provider, amount, availableAmount, originalAmount);
+
+        return poolTokenAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -839,21 +839,18 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint256 amount,
         uint256 availableAmount,
         uint256 originalAmount
-    ) external payable whenNotPaused onlyRoleMember(ROLE_MIGRATION_MANAGER) nonReentrant returns (uint256) {
+    ) external payable whenNotPaused onlyRoleMember(ROLE_MIGRATION_MANAGER) nonReentrant {
         bytes32 contextId = keccak256(
             abi.encodePacked(msg.sender, _time(), token, provider, amount, availableAmount, originalAmount)
         );
 
-        uint256 poolTokenAmount;
         if (token.isEqual(_bnt)) {
-            poolTokenAmount = _depositBNTFor(contextId, provider, amount, msg.sender, true, originalAmount);
+            _depositBNTFor(contextId, provider, amount, msg.sender, true, originalAmount);
         } else {
-            poolTokenAmount = _depositBaseTokenFor(contextId, provider, token, amount, msg.sender, availableAmount);
+            _depositBaseTokenFor(contextId, provider, token, amount, msg.sender, availableAmount);
         }
 
         emit FundsMigrated(contextId, token, provider, amount, availableAmount, originalAmount);
-
-        return poolTokenAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -784,7 +784,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         validAddress(address(recipient))
         whenNotPaused
         nonReentrant
-        returns (uint256)
     {
         if (!token.isEqual(_bnt) && !_networkSettings.isTokenWhitelisted(token)) {
             revert NotWhitelisted();
@@ -826,8 +825,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         }
 
         emit FlashLoanCompleted({ token: token, borrower: msg.sender, amount: amount, feeAmount: feeAmount });
-
-        return feeAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -681,10 +681,10 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint256 minReturnAmount,
         uint256 deadline,
         address beneficiary
-    ) external payable whenNotPaused nonReentrant {
+    ) external payable whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, sourceAmount, minReturnAmount, deadline);
 
-        _trade(
+        return _trade(
             TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
             TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
             TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
@@ -705,12 +705,12 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external whenNotPaused nonReentrant {
+    ) external whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, sourceAmount, minReturnAmount, deadline);
 
         sourceToken.permit(msg.sender, address(this), sourceAmount, deadline, Signature({ v: v, r: r, s: s }));
 
-        _trade(
+        return _trade(
             TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
             TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
             TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
@@ -728,10 +728,10 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint256 maxSourceAmount,
         uint256 deadline,
         address beneficiary
-    ) external payable whenNotPaused nonReentrant {
+    ) external payable whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, targetAmount, maxSourceAmount, deadline);
 
-        _trade(
+        return _trade(
             TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
             TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
             TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
@@ -752,12 +752,12 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external whenNotPaused nonReentrant {
+    ) external whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, targetAmount, maxSourceAmount, deadline);
 
         sourceToken.permit(msg.sender, address(this), maxSourceAmount, deadline, Signature({ v: v, r: r, s: s }));
 
-        _trade(
+        return _trade(
             TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
             TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
             TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
@@ -1132,7 +1132,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         TradeParams memory params,
         TraderInfo memory traderInfo,
         uint256 deadline
-    ) private {
+    ) private returns (uint256) {
         // ensure the beneficiary is set
         if (traderInfo.beneficiary == address(0)) {
             traderInfo.beneficiary = traderInfo.trader;
@@ -1211,6 +1211,8 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
 
         // update the pending network fee amount to be burned by the vortex
         _pendingNetworkFeeAmount += networkFeeAmount;
+
+        return params.bySourceAmount ? lastHopTradeResult.targetAmount : lastHopTradeResult.sourceAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -784,6 +784,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         validAddress(address(recipient))
         whenNotPaused
         nonReentrant
+        returns (uint256)
     {
         if (!token.isEqual(_bnt) && !_networkSettings.isTokenWhitelisted(token)) {
             revert NotWhitelisted();
@@ -825,6 +826,8 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         }
 
         emit FlashLoanCompleted({ token: token, borrower: msg.sender, amount: amount, feeAmount: feeAmount });
+
+        return feeAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -864,10 +864,11 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         whenNotPaused
         onlyRoleMember(ROLE_NETWORK_FEE_MANAGER)
         validAddress(recipient)
+        returns (uint256)
     {
         uint256 currentPendingNetworkFeeAmount = _pendingNetworkFeeAmount;
         if (currentPendingNetworkFeeAmount == 0) {
-            return;
+            return 0;
         }
 
         _pendingNetworkFeeAmount = 0;
@@ -875,6 +876,8 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         _masterVault.withdrawFunds(Token(address(_bnt)), payable(recipient), currentPendingNetworkFeeAmount);
 
         emit NetworkFeesWithdrawn(msg.sender, recipient, currentPendingNetworkFeeAmount);
+
+        return currentPendingNetworkFeeAmount;
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -650,8 +650,8 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     /**
      * @inheritdoc IBancorNetwork
      */
-    function cancelWithdrawal(uint256 id) external whenNotPaused nonReentrant {
-        _pendingWithdrawals.cancelWithdrawal(msg.sender, id);
+    function cancelWithdrawal(uint256 id) external whenNotPaused nonReentrant returns (uint256) {
+        return _pendingWithdrawals.cancelWithdrawal(msg.sender, id);
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -684,12 +684,13 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     ) external payable whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, sourceAmount, minReturnAmount, deadline);
 
-        return _trade(
-            TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
-            TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
-            TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
-            deadline
-        );
+        return
+            _trade(
+                TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
+                TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
+                TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
+                deadline
+            );
     }
 
     /**
@@ -710,12 +711,13 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
 
         sourceToken.permit(msg.sender, address(this), sourceAmount, deadline, Signature({ v: v, r: r, s: s }));
 
-        return _trade(
-            TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
-            TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
-            TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
-            deadline
-        );
+        return
+            _trade(
+                TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
+                TradeParams({ bySourceAmount: true, amount: sourceAmount, limit: minReturnAmount }),
+                TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
+                deadline
+            );
     }
 
     /**
@@ -731,12 +733,13 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     ) external payable whenNotPaused nonReentrant returns (uint256) {
         _verifyTradeParams(sourceToken, targetToken, targetAmount, maxSourceAmount, deadline);
 
-        return _trade(
-            TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
-            TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
-            TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
-            deadline
-        );
+        return
+            _trade(
+                TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
+                TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
+                TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
+                deadline
+            );
     }
 
     /**
@@ -757,12 +760,13 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
 
         sourceToken.permit(msg.sender, address(this), maxSourceAmount, deadline, Signature({ v: v, r: r, s: s }));
 
-        return _trade(
-            TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
-            TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
-            TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
-            deadline
-        );
+        return
+            _trade(
+                TradeTokens({ sourceToken: sourceToken, targetToken: targetToken }),
+                TradeParams({ bySourceAmount: false, amount: targetAmount, limit: maxSourceAmount }),
+                TraderInfo({ trader: msg.sender, beneficiary: beneficiary }),
+                deadline
+            );
     }
 
     /**

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -1162,12 +1162,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
         uint256 networkFeeAmount;
 
         if (tokens.sourceToken.isEqual(_bnt)) {
-            lastHopTradeResult = _tradeBNT(
-                contextId,
-                tokens.targetToken,
-                true,
-                params
-            );
+            lastHopTradeResult = _tradeBNT(contextId, tokens.targetToken, true, params);
 
             firstHopTradeResult = lastHopTradeResult;
 
@@ -1185,12 +1180,7 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
                 trader: traderInfo.trader
             });
         } else if (tokens.targetToken.isEqual(_bnt)) {
-            lastHopTradeResult = _tradeBNT(
-                contextId,
-                tokens.sourceToken,
-                false,
-                params
-            );
+            lastHopTradeResult = _tradeBNT(contextId, tokens.sourceToken, false, params);
 
             firstHopTradeResult = lastHopTradeResult;
 

--- a/contracts/network/PendingWithdrawals.sol
+++ b/contracts/network/PendingWithdrawals.sol
@@ -353,7 +353,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, Time, Utils {
     /**
      * @dev cancels a withdrawal request
      */
-    function _cancelWithdrawal(WithdrawalRequest memory request, uint256 id) private {
+    function _cancelWithdrawal(WithdrawalRequest memory request, uint256 id) private returns (uint256) {
         // remove the withdrawal request and its id from the storage
         _removeWithdrawalRequest(request.provider, id);
 
@@ -368,6 +368,8 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, Time, Utils {
             reserveTokenAmount: request.reserveTokenAmount,
             timeElapsed: _time() - request.createdAt
         });
+
+        return request.reserveTokenAmount;
     }
 
     /**

--- a/contracts/network/PendingWithdrawals.sol
+++ b/contracts/network/PendingWithdrawals.sol
@@ -203,14 +203,14 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, Time, Utils {
     /**
      * @inheritdoc IPendingWithdrawals
      */
-    function cancelWithdrawal(address provider, uint256 id) external only(address(_network)) {
+    function cancelWithdrawal(address provider, uint256 id) external only(address(_network)) returns (uint256) {
         WithdrawalRequest memory request = _withdrawalRequests[id];
 
         if (request.provider != provider) {
             revert AccessDenied();
         }
 
-        _cancelWithdrawal(request, id);
+        return _cancelWithdrawal(request, id);
     }
 
     /**

--- a/contracts/network/PendingWithdrawals.sol
+++ b/contracts/network/PendingWithdrawals.sol
@@ -369,7 +369,7 @@ contract PendingWithdrawals is IPendingWithdrawals, Upgradeable, Time, Utils {
             timeElapsed: _time() - request.createdAt
         });
 
-        return request.reserveTokenAmount;
+        return request.poolTokenAmount;
     }
 
     /**

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -284,7 +284,7 @@ interface IBancorNetwork is IUpgradeable {
     /**
      * @dev deposits liquidity during a migration
      * returns:
-     * - the amount of base pool tokens minted for the user, when base token are migrated
+     * - the amount of base pool tokens minted for the user, when base tokens are migrated
      * - the amount of BNT pool tokens transferred to the user, when BNT tokens are migrated
      */
     function migrateLiquidity(

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -295,10 +295,11 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev withdraws pending network fees
+     * returns the amount of fees withdrawn
      *
      * requirements:
      *
      * - the caller must have the ROLE_NETWORK_FEE_MANAGER privilege
      */
-    function withdrawNetworkFees(address recipient) external;
+    function withdrawNetworkFees(address recipient) external returns (uint256);
 }

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -167,7 +167,8 @@ interface IBancorNetwork is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev cancels a withdrawal request, and returns the number of reserve tokens associated with the withdrawal request
+     * @dev cancels a withdrawal request, and returns the number of pool token amount associated with the withdrawal
+     * request
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -268,6 +268,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev provides a flash-loan
+     * returns the amount of fee paid
      *
      * requirements:
      *
@@ -278,7 +279,7 @@ interface IBancorNetwork is IUpgradeable {
         uint256 amount,
         IFlashLoanRecipient recipient,
         bytes calldata data
-    ) external;
+    ) external returns (uint256);
 
     /**
      * @dev deposits liquidity during a migration

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -282,6 +282,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev deposits liquidity during a migration
+     * returns the amount of pool tokens issued
      */
     function migrateLiquidity(
         Token token,
@@ -289,7 +290,7 @@ interface IBancorNetwork is IUpgradeable {
         uint256 amount,
         uint256 availableAmount,
         uint256 originalAmount
-    ) external payable;
+    ) external payable returns (uint256);
 
     /**
      * @dev withdraws pending network fees

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -283,9 +283,6 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev deposits liquidity during a migration
-     * returns:
-     * - the amount of base pool tokens minted for the user, when base tokens are migrated
-     * - the amount of BNT pool tokens transferred to the user, when BNT tokens are migrated
      */
     function migrateLiquidity(
         Token token,
@@ -293,7 +290,7 @@ interface IBancorNetwork is IUpgradeable {
         uint256 amount,
         uint256 availableAmount,
         uint256 originalAmount
-    ) external payable returns (uint256);
+    ) external payable;
 
     /**
      * @dev withdraws pending network fees

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -283,7 +283,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev deposits liquidity during a migration
-     * returns the amount of pool tokens issued
+     * returns the amount of pool tokens minted
      */
     function migrateLiquidity(
         Token token,

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -168,7 +168,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev cancels a withdrawal request
-     * returns the value of the position in units of the reserve token
+     * returns the number of reserve tokens associated with the withdrawal request
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -262,7 +262,7 @@ interface IBancorNetwork is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev provides a flash-loan, and returns the amount of fee paid
+     * @dev provides a flash-loan
      *
      * requirements:
      *
@@ -273,7 +273,7 @@ interface IBancorNetwork is IUpgradeable {
         uint256 amount,
         IFlashLoanRecipient recipient,
         bytes calldata data
-    ) external returns (uint256);
+    ) external;
 
     /**
      * @dev deposits liquidity during a migration

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -283,7 +283,9 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev deposits liquidity during a migration
-     * returns the amount of pool tokens minted
+     * returns:
+     * - the amount of base pool tokens minted for the user, when base token are migrated
+     * - the amount of BNT pool tokens transferred to the user, when BNT tokens are migrated
      */
     function migrateLiquidity(
         Token token,

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -190,6 +190,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev performs a trade by providing the input source amount
+     * returns the trade target amount
      *
      * requirements:
      *
@@ -203,11 +204,12 @@ interface IBancorNetwork is IUpgradeable {
         uint256 minReturnAmount,
         uint256 deadline,
         address beneficiary
-    ) external payable;
+    ) external payable returns (uint256);
 
     /**
      * @dev performs a trade by providing the input source amount and providing an EIP712 typed signature for an
      * EIP2612 permit request
+     * returns the trade target amount
      *
      * requirements:
      *
@@ -223,10 +225,11 @@ interface IBancorNetwork is IUpgradeable {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external;
+    ) external returns (uint256);
 
     /**
      * @dev performs a trade by providing the output target amount
+     * returns the trade source amount
      *
      * requirements:
      *
@@ -240,11 +243,12 @@ interface IBancorNetwork is IUpgradeable {
         uint256 maxSourceAmount,
         uint256 deadline,
         address beneficiary
-    ) external payable;
+    ) external payable returns (uint256);
 
     /**
      * @dev performs a trade by providing the output target amount and providing an EIP712 typed signature for an
      * EIP2612 permit request and returns the target amount and fee
+     * returns the trade source amount
      *
      * requirements:
      *
@@ -260,7 +264,7 @@ interface IBancorNetwork is IUpgradeable {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external;
+    ) external returns (uint256);
 
     /**
      * @dev provides a flash-loan

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -168,12 +168,13 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev cancels a withdrawal request
+     * returns the value of the position in units of the reserve token
      *
      * requirements:
      *
      * - the caller must have already initiated a withdrawal and received the specified id
      */
-    function cancelWithdrawal(uint256 id) external;
+    function cancelWithdrawal(uint256 id) external returns (uint256);
 
     /**
      * @dev withdraws liquidity and returns the withdrawn amount

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -167,8 +167,7 @@ interface IBancorNetwork is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev cancels a withdrawal request
-     * returns the number of reserve tokens associated with the withdrawal request
+     * @dev cancels a withdrawal request, and returns the number of reserve tokens associated with the withdrawal request
      *
      * requirements:
      *
@@ -189,8 +188,7 @@ interface IBancorNetwork is IUpgradeable {
     function withdraw(uint256 id) external returns (uint256);
 
     /**
-     * @dev performs a trade by providing the input source amount
-     * returns the trade target amount
+     * @dev performs a trade by providing the input source amount, and returns the trade target amount
      *
      * requirements:
      *
@@ -208,8 +206,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev performs a trade by providing the input source amount and providing an EIP712 typed signature for an
-     * EIP2612 permit request
-     * returns the trade target amount
+     * EIP2612 permit request, and returns the trade target amount
      *
      * requirements:
      *
@@ -228,8 +225,7 @@ interface IBancorNetwork is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev performs a trade by providing the output target amount
-     * returns the trade source amount
+     * @dev performs a trade by providing the output target amount, and returns the trade source amount
      *
      * requirements:
      *
@@ -247,8 +243,7 @@ interface IBancorNetwork is IUpgradeable {
 
     /**
      * @dev performs a trade by providing the output target amount and providing an EIP712 typed signature for an
-     * EIP2612 permit request and returns the target amount and fee
-     * returns the trade source amount
+     * EIP2612 permit request and returns the target amount and fee, and returns the trade source amount
      *
      * requirements:
      *
@@ -267,8 +262,7 @@ interface IBancorNetwork is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev provides a flash-loan
-     * returns the amount of fee paid
+     * @dev provides a flash-loan, and returns the amount of fee paid
      *
      * requirements:
      *
@@ -293,8 +287,7 @@ interface IBancorNetwork is IUpgradeable {
     ) external payable;
 
     /**
-     * @dev withdraws pending network fees
-     * returns the amount of fees withdrawn
+     * @dev withdraws pending network fees, and returns the amount of fees withdrawn
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -66,7 +66,7 @@ interface IPendingWithdrawals is IUpgradeable {
 
     /**
      * @dev cancels a withdrawal request
-     * returns the value of the position in units of the reserve token
+     * returns the number of reserve tokens associated with the withdrawal request
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -75,7 +75,7 @@ interface IPendingWithdrawals is IUpgradeable {
     function cancelWithdrawal(address provider, uint256 id) external returns (uint256);
 
     /**
-     * @dev completes a withdrawal request and returns the pool token and its transferred amount
+     * @dev completes a withdrawal request, and returns the pool token and its transferred amount
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -65,8 +65,7 @@ interface IPendingWithdrawals is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev cancels a withdrawal request
-     * returns the number of reserve tokens associated with the withdrawal request
+     * @dev cancels a withdrawal request, and returns the number of reserve tokens associated with the withdrawal request
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -65,7 +65,7 @@ interface IPendingWithdrawals is IUpgradeable {
     ) external returns (uint256);
 
     /**
-     * @dev cancels a withdrawal request, and returns the number of reserve tokens associated with the withdrawal request
+     * @dev cancels a withdrawal request, and returns the number of pool tokens which were sent back to the provider
      *
      * requirements:
      *

--- a/contracts/network/interfaces/IPendingWithdrawals.sol
+++ b/contracts/network/interfaces/IPendingWithdrawals.sol
@@ -66,13 +66,14 @@ interface IPendingWithdrawals is IUpgradeable {
 
     /**
      * @dev cancels a withdrawal request
+     * returns the value of the position in units of the reserve token
      *
      * requirements:
      *
      * - the caller must be the network contract
      * - the provider must have already initiated a withdrawal and received the specified id
      */
-    function cancelWithdrawal(address provider, uint256 id) external;
+    function cancelWithdrawal(address provider, uint256 id) external returns (uint256);
 
     /**
      * @dev completes a withdrawal request and returns the pool token and its transferred amount

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3928,6 +3928,9 @@ describe('BancorNetwork', () => {
             it('should not withdraw any pending network fees', async () => {
                 const prevBNTBalance = await bnt.balanceOf(networkFeeManager.address);
 
+                const val = await network.connect(networkFeeManager).callStatic.withdrawNetworkFees(networkFeeManager.address);
+                expect(val).to.equal(0);
+
                 const res = await network.connect(networkFeeManager).withdrawNetworkFees(networkFeeManager.address);
 
                 await expect(res).to.not.emit(network, 'NetworkFeesWithdrawn');
@@ -3959,6 +3962,9 @@ describe('BancorNetwork', () => {
                 const recipient = nonOwner.address;
                 const prevBNTBalance = await bnt.balanceOf(networkFeeManager.address);
                 const pendingNetworkFeeAmount = await network.pendingNetworkFeeAmount();
+
+                const val = await network.connect(networkFeeManager).callStatic.withdrawNetworkFees(recipient);
+                expect(val).to.equal(pendingNetworkFeeAmount);
 
                 const res = await network.connect(networkFeeManager).withdrawNetworkFees(recipient);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2117,11 +2117,7 @@ describe('BancorNetwork', () => {
             targetTokenAddress?: string;
         }
 
-        const tradeBySourceAmount = async (
-            amount: BigNumberish,
-            overrides: TradeOverrides = {},
-            callStatic = false
-        ) => {
+        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, simulate = false) => {
             let {
                 value,
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
@@ -2133,9 +2129,9 @@ describe('BancorNetwork', () => {
 
             value ||= sourceTokenAddress === NATIVE_TOKEN_ADDRESS ? amount : BigNumber.from(0);
 
-            const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
+            const method = simulate ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller.tradeBySourceAmount(
+            return method.tradeBySourceAmount(
                 sourceTokenAddress,
                 targetTokenAddress,
                 amount,
@@ -2148,11 +2144,7 @@ describe('BancorNetwork', () => {
             );
         };
 
-        const tradeByTargetAmount = async (
-            amount: BigNumberish,
-            overrides: TradeOverrides = {},
-            callStatic = false
-        ) => {
+        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, simulate = false) => {
             let {
                 value,
                 limit: maxSourceAmount,
@@ -2179,9 +2171,9 @@ describe('BancorNetwork', () => {
                 }
             }
 
-            const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
+            const method = simulate ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller.tradeByTargetAmount(
+            return method.tradeByTargetAmount(
                 sourceTokenAddress,
                 targetTokenAddress,
                 amount,
@@ -2206,7 +2198,7 @@ describe('BancorNetwork', () => {
         const tradeBySourceAmountPermitted = async (
             amount: BigNumberish,
             overrides: TradePermittedOverrides = {},
-            callStatic = false
+            simulate = false
         ) => {
             const {
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
@@ -2219,9 +2211,9 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
+            const method = simulate ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller.tradeBySourceAmountPermitted(
+            return method.tradeBySourceAmountPermitted(
                 sourceTokenAddress,
                 targetTokenAddress,
                 amount,
@@ -2237,7 +2229,7 @@ describe('BancorNetwork', () => {
         const tradeByTargetAmountPermitted = async (
             amount: BigNumberish,
             overrides: TradePermittedOverrides = {},
-            callStatic = false
+            simulate = false
         ) => {
             let {
                 limit: maxSourceAmount,
@@ -2258,9 +2250,9 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
+            const method = simulate ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller.tradeByTargetAmountPermitted(
+            return method.tradeByTargetAmountPermitted(
                 sourceTokenAddress,
                 targetTokenAddress,
                 amount,
@@ -2280,7 +2272,7 @@ describe('BancorNetwork', () => {
             tradeFunc: (
                 amount: BigNumberish,
                 options: TradeOverrides | TradePermittedOverrides,
-                callStatic: boolean
+                simulate: boolean
             ) => Promise<ContractTransaction | BigNumber | void>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2702,15 +2702,17 @@ describe('BancorNetwork', () => {
                                     const tradeFunc = permitted ? tradeBySourceAmountPermittedFunc : tradeDirectFunc;
 
                                     it('should revert when attempting to trade using an invalid source token', async () => {
-                                        await expect(
-                                            tradeFunc(testAmount, { sourceTokenAddress: ZERO_ADDRESS })
-                                        ).to.be.revertedWith('InvalidAddress');
+                                        const { res } = await tradeFunc(testAmount, {
+                                            sourceTokenAddress: ZERO_ADDRESS
+                                        });
+                                        await expect(res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid target token', async () => {
-                                        await expect(
-                                            tradeFunc(testAmount, { targetTokenAddress: ZERO_ADDRESS })
-                                        ).to.be.revertedWith('InvalidAddress');
+                                        const { res } = await tradeFunc(testAmount, {
+                                            targetTokenAddress: ZERO_ADDRESS
+                                        });
+                                        await expect(res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid amount', async () => {
@@ -2719,9 +2721,8 @@ describe('BancorNetwork', () => {
                                     });
 
                                     it('should revert when attempting to trade using an invalid limit', async () => {
-                                        await expect(
-                                            tradeFunc(testAmount, { limit: BigNumber.from(0) })
-                                        ).to.be.revertedWith('ZeroValue');
+                                        const { res } = await tradeFunc(testAmount, { limit: BigNumber.from(0) });
+                                        await expect(res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an expired deadline', async () => {
@@ -2740,20 +2741,23 @@ describe('BancorNetwork', () => {
                                         }
 
                                         // unknown source token
-                                        await expect(
-                                            tradeFunc(testAmount, { sourceTokenAddress: reserveToken2.address })
-                                        ).to.be.revertedWith('InvalidToken');
+                                        const { res: res1 } = await tradeFunc(testAmount, {
+                                            sourceTokenAddress: reserveToken2.address
+                                        });
+                                        await expect(res1).to.be.revertedWith('InvalidToken');
 
                                         // unknown target token
-                                        await expect(
-                                            tradeFunc(testAmount, { targetTokenAddress: reserveToken2.address })
-                                        ).to.be.revertedWith('InvalidToken');
+                                        const { res: res2 } = await tradeFunc(testAmount, {
+                                            targetTokenAddress: reserveToken2.address
+                                        });
+                                        await expect(res2).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should revert when attempting to trade using same source and target tokens', async () => {
-                                        await expect(
-                                            tradeFunc(testAmount, { targetTokenAddress: sourceToken.address })
-                                        ).to.be.revertedWith('InvalidToken');
+                                        const { res } = await tradeFunc(testAmount, {
+                                            targetTokenAddress: sourceToken.address
+                                        });
+                                        await expect(res).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should support a custom beneficiary', async () => {
@@ -2782,11 +2786,12 @@ describe('BancorNetwork', () => {
                                                 if (permitted) {
                                                     // perform a permitted trade while signing a permit over an amount lower
                                                     // than the required amount
-                                                    await expect(
-                                                        tradeBySourceAmountPermittedFunc(testAmount, {
-                                                            approvedAmount: sourceAmount.sub(missingAmount)
-                                                        })
-                                                    ).to.be.revertedWith('ERC20Permit: invalid signature');
+                                                    const { res } = await tradeBySourceAmountPermittedFunc(testAmount, {
+                                                        approvedAmount: sourceAmount.sub(missingAmount)
+                                                    });
+                                                    await expect(res).to.be.revertedWith(
+                                                        'ERC20Permit: invalid signature'
+                                                    );
                                                 } else {
                                                     // reduce the approved amount and perform a trade by providing the source
                                                     // amount

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2688,9 +2688,8 @@ describe('BancorNetwork', () => {
                                 });
                             } else {
                                 it('should revert when passing the native token with a non native token trade', async () => {
-                                    await expect(tradeDirectFunc(testAmount, { value: 100 })).to.be.revertedWith(
-                                        'NativeTokenAmountMismatch'
-                                    );
+                                    const { res } = await tradeDirectFunc(testAmount, { value: 100 });
+                                    await expect(res).to.be.revertedWith('NativeTokenAmountMismatch');
                                 });
                             }
 
@@ -2715,7 +2714,8 @@ describe('BancorNetwork', () => {
                                     });
 
                                     it('should revert when attempting to trade using an invalid amount', async () => {
-                                        await expect(tradeFunc(BigNumber.from(0))).to.be.revertedWith('ZeroValue');
+                                        const { res } = await tradeFunc(BigNumber.from(0));
+                                        await expect(res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an invalid limit', async () => {
@@ -2727,9 +2727,8 @@ describe('BancorNetwork', () => {
                                     it('should revert when attempting to trade using an expired deadline', async () => {
                                         const deadline = (await latest()) - 1000;
 
-                                        await expect(tradeFunc(testAmount, { deadline })).to.be.revertedWith(
-                                            'DeadlineExpired'
-                                        );
+                                        const { res } = await tradeFunc(testAmount, { deadline });
+                                        await expect(res).to.be.revertedWith('DeadlineExpired');
                                     });
 
                                     it('should revert when attempting to trade unsupported tokens', async () => {
@@ -2799,7 +2798,8 @@ describe('BancorNetwork', () => {
                                                         .connect(trader)
                                                         .approve(network.address, sourceAmount.sub(missingAmount));
 
-                                                    await expect(tradeFunc(testAmount)).to.be.revertedWith(
+                                                    const { res } = await tradeFunc(testAmount);
+                                                    await expect(res).to.be.revertedWith(
                                                         source.tokenData.errors().exceedsAllowance
                                                     );
                                                 }
@@ -2813,7 +2813,8 @@ describe('BancorNetwork', () => {
                                         });
 
                                         it('should revert when attempting to trade', async () => {
-                                            await expect(tradeFunc(testAmount)).to.be.revertedWith('Pausable: paused');
+                                            const { res } = await tradeFunc(testAmount);
+                                            await expect(res).to.be.revertedWith('Pausable: paused');
                                         });
                                     });
                                 });
@@ -2890,7 +2891,8 @@ describe('BancorNetwork', () => {
 
                             if (isSourceNativeToken || isSourceBNT) {
                                 it('should revert when attempting a permitted trade', async () => {
-                                    await expect(tradeFunc(amount)).to.be.revertedWith(
+                                    const { res } = await tradeFunc(amount);
+                                    await expect(res).to.be.revertedWith(
                                         isSourceNativeToken ? 'PermitUnsupported' : ''
                                     );
                                 });

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3073,8 +3073,13 @@ describe('BancorNetwork', () => {
 
                 const data = '0x1234';
 
-                const val = await network.callStatic.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
-                expect(val).to.equal(FEE_AMOUNT);
+                const feeAmount = await network.callStatic.flashLoan(
+                    token.address,
+                    LOAN_AMOUNT,
+                    recipient.address,
+                    data
+                );
+                expect(feeAmount).to.equal(FEE_AMOUNT);
 
                 const res = await network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
 
@@ -3890,8 +3895,8 @@ describe('BancorNetwork', () => {
 
             it('should cancel a pending withdrawal request', async () => {
                 const withdrawalRequest = await pendingWithdrawals.withdrawalRequest(id);
-                const val = await network.connect(provider).callStatic.cancelWithdrawal(id);
-                expect(val).to.equal(withdrawalRequest.reserveTokenAmount);
+                const reserveTokenAmount = await network.connect(provider).callStatic.cancelWithdrawal(id);
+                expect(reserveTokenAmount).to.equal(withdrawalRequest.reserveTokenAmount);
 
                 await network.connect(provider).cancelWithdrawal(id);
 
@@ -3968,10 +3973,10 @@ describe('BancorNetwork', () => {
             it('should not withdraw any pending network fees', async () => {
                 const prevBNTBalance = await bnt.balanceOf(networkFeeManager.address);
 
-                const val = await network
+                const withdrawNetworkFees = await network
                     .connect(networkFeeManager)
                     .callStatic.withdrawNetworkFees(networkFeeManager.address);
-                expect(val).to.equal(0);
+                expect(withdrawNetworkFees).to.equal(0);
 
                 const res = await network.connect(networkFeeManager).withdrawNetworkFees(networkFeeManager.address);
 
@@ -4005,8 +4010,10 @@ describe('BancorNetwork', () => {
                 const prevBNTBalance = await bnt.balanceOf(networkFeeManager.address);
                 const pendingNetworkFeeAmount = await network.pendingNetworkFeeAmount();
 
-                const val = await network.connect(networkFeeManager).callStatic.withdrawNetworkFees(recipient);
-                expect(val).to.equal(pendingNetworkFeeAmount);
+                const withdrawNetworkFees = await network
+                    .connect(networkFeeManager)
+                    .callStatic.withdrawNetworkFees(recipient);
+                expect(withdrawNetworkFees).to.equal(pendingNetworkFeeAmount);
 
                 const res = await network.connect(networkFeeManager).withdrawNetworkFees(recipient);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3879,8 +3879,8 @@ describe('BancorNetwork', () => {
 
             it('should cancel a pending withdrawal request', async () => {
                 const withdrawalRequest = await pendingWithdrawals.withdrawalRequest(id);
-                const reserveTokenAmount = await network.connect(provider).callStatic.cancelWithdrawal(id);
-                expect(reserveTokenAmount).to.equal(withdrawalRequest.reserveTokenAmount);
+                const poolTokenAmount = await network.connect(provider).callStatic.cancelWithdrawal(id);
+                expect(poolTokenAmount).to.equal(withdrawalRequest.poolTokenAmount);
 
                 await network.connect(provider).cancelWithdrawal(id);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2117,7 +2117,7 @@ describe('BancorNetwork', () => {
             targetTokenAddress?: string;
         }
 
-        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, getRetVal = false) => {
+        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
             let {
                 value,
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
@@ -2129,42 +2129,22 @@ describe('BancorNetwork', () => {
 
             value ||= sourceTokenAddress === NATIVE_TOKEN_ADDRESS ? amount : BigNumber.from(0);
 
-            let retVal = BigNumber.from(0);
-            if (getRetVal) {
-                retVal = await network
-                    .connect(trader)
-                    .callStatic.tradeBySourceAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    );
-            }
-
-            return {
-                retVal,
-                res: network
-                    .connect(trader)
-                    .tradeBySourceAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeBySourceAmount(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    minReturnAmount,
+                    deadline,
+                    beneficiary,
+                    {
+                        value
+                    }
+                );
         };
 
-        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, getRetVal = false) => {
+        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
             let {
                 value,
                 limit: maxSourceAmount,
@@ -2191,39 +2171,19 @@ describe('BancorNetwork', () => {
                 }
             }
 
-            let retVal = BigNumber.from(0);
-            if (getRetVal) {
-                retVal = await network
-                    .connect(trader)
-                    .callStatic.tradeByTargetAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    );
-            }
-
-            return {
-                retVal,
-                res: network
-                    .connect(trader)
-                    .tradeByTargetAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeByTargetAmount(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    maxSourceAmount,
+                    deadline,
+                    beneficiary,
+                    {
+                        value
+                    }
+                );
         };
 
         interface TradePermittedOverrides {
@@ -2235,11 +2195,7 @@ describe('BancorNetwork', () => {
             approvedAmount?: BigNumberish;
         }
 
-        const tradeBySourceAmountPermitted = async (
-            amount: BigNumberish,
-            overrides: TradePermittedOverrides = {},
-            getRetVal = false
-        ) => {
+        const tradeBySourceAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
             const {
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
                 deadline = MAX_UINT256,
@@ -2251,46 +2207,22 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            let retVal = BigNumber.from(0);
-            if (getRetVal) {
-                retVal = await network
-                    .connect(trader)
-                    .callStatic.tradeBySourceAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    );
-            }
-
-            return {
-                retVal,
-                res: network
-                    .connect(trader)
-                    .tradeBySourceAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeBySourceAmountPermitted(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    minReturnAmount,
+                    deadline,
+                    beneficiary,
+                    signature.v,
+                    signature.r,
+                    signature.s
+                );
         };
 
-        const tradeByTargetAmountPermitted = async (
-            amount: BigNumberish,
-            overrides: TradePermittedOverrides = {},
-            getRetVal = false
-        ) => {
+        const tradeByTargetAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
             let {
                 limit: maxSourceAmount,
                 deadline = MAX_UINT256,
@@ -2310,39 +2242,19 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            let retVal = BigNumber.from(0);
-            if (getRetVal) {
-                retVal = await network
-                    .connect(trader)
-                    .callStatic.tradeByTargetAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    );
-            }
-
-            return {
-                retVal,
-                res: network
-                    .connect(trader)
-                    .tradeByTargetAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeByTargetAmountPermitted(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    maxSourceAmount,
+                    deadline,
+                    beneficiary,
+                    signature.v,
+                    signature.r,
+                    signature.s
+                );
         };
 
         const verifyTrade = async (
@@ -2351,9 +2263,8 @@ describe('BancorNetwork', () => {
             amount: BigNumberish,
             tradeFunc: (
                 amount: BigNumberish,
-                options: TradeOverrides | TradePermittedOverrides,
-                getRetVal: boolean
-            ) => Promise<{ retVal: BigNumber; res: Promise<ContractTransaction> }>
+                options: TradeOverrides | TradePermittedOverrides
+            ) => Promise<ContractTransaction>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;
             const isTargetNativeToken = targetToken.address === NATIVE_TOKEN_ADDRESS;
@@ -2483,19 +2394,13 @@ describe('BancorNetwork', () => {
                 pendingNetworkFeeAmount = pendingNetworkFeeAmount.add(hop1.networkFeeAmount.add(hop2.networkFeeAmount));
             }
 
-            const { retVal, res } = await tradeFunc(
-                amount,
-                {
-                    limit,
-                    beneficiary: beneficiaryAddress,
-                    deadline
-                },
-                true
-            );
+            const res = await tradeFunc(amount, {
+                limit,
+                beneficiary: beneficiaryAddress,
+                deadline
+            });
 
-            expect(retVal).to.equal(hop2.amount);
-
-            const transactionCost = await getTransactionCost(await res);
+            const transactionCost = await getTransactionCost(res);
 
             const contextId = solidityKeccak256(
                 ['address', 'uint32', 'address', 'address', 'uint256', 'uint256', 'bool', 'uint256', 'address'],
@@ -2676,11 +2581,11 @@ describe('BancorNetwork', () => {
                                     const extraAmount = 100_000;
                                     const prevTraderBalance = await getBalance(sourceToken, trader);
 
-                                    const { res } = await tradeDirectFunc(testAmount, {
+                                    const res = await tradeDirectFunc(testAmount, {
                                         value: sourceAmount.add(extraAmount)
                                     });
 
-                                    const transactionCost = await getTransactionCost(await res);
+                                    const transactionCost = await getTransactionCost(res);
 
                                     expect(await getBalance(sourceToken, trader)).equal(
                                         prevTraderBalance.sub(sourceAmount).sub(transactionCost)
@@ -2688,8 +2593,9 @@ describe('BancorNetwork', () => {
                                 });
                             } else {
                                 it('should revert when passing the native token with a non native token trade', async () => {
-                                    const { res } = await tradeDirectFunc(testAmount, { value: 100 });
-                                    await expect(res).to.be.revertedWith('NativeTokenAmountMismatch');
+                                    await expect(tradeDirectFunc(testAmount, { value: 100 })).to.be.revertedWith(
+                                        'NativeTokenAmountMismatch'
+                                    );
                                 });
                             }
 
@@ -2702,34 +2608,33 @@ describe('BancorNetwork', () => {
                                     const tradeFunc = permitted ? tradeBySourceAmountPermittedFunc : tradeDirectFunc;
 
                                     it('should revert when attempting to trade using an invalid source token', async () => {
-                                        const { res } = await tradeFunc(testAmount, {
-                                            sourceTokenAddress: ZERO_ADDRESS
-                                        });
-                                        await expect(res).to.be.revertedWith('InvalidAddress');
+                                        await expect(
+                                            tradeFunc(testAmount, { sourceTokenAddress: ZERO_ADDRESS })
+                                        ).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid target token', async () => {
-                                        const { res } = await tradeFunc(testAmount, {
-                                            targetTokenAddress: ZERO_ADDRESS
-                                        });
-                                        await expect(res).to.be.revertedWith('InvalidAddress');
+                                        await expect(
+                                            tradeFunc(testAmount, { targetTokenAddress: ZERO_ADDRESS })
+                                        ).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid amount', async () => {
-                                        const { res } = await tradeFunc(BigNumber.from(0));
-                                        await expect(res).to.be.revertedWith('ZeroValue');
+                                        await expect(tradeFunc(BigNumber.from(0))).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an invalid limit', async () => {
-                                        const { res } = await tradeFunc(testAmount, { limit: BigNumber.from(0) });
-                                        await expect(res).to.be.revertedWith('ZeroValue');
+                                        await expect(
+                                            tradeFunc(testAmount, { limit: BigNumber.from(0) })
+                                        ).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an expired deadline', async () => {
                                         const deadline = (await latest()) - 1000;
 
-                                        const { res } = await tradeFunc(testAmount, { deadline });
-                                        await expect(res).to.be.revertedWith('DeadlineExpired');
+                                        await expect(tradeFunc(testAmount, { deadline })).to.be.revertedWith(
+                                            'DeadlineExpired'
+                                        );
                                     });
 
                                     it('should revert when attempting to trade unsupported tokens', async () => {
@@ -2741,23 +2646,20 @@ describe('BancorNetwork', () => {
                                         }
 
                                         // unknown source token
-                                        const { res: res1 } = await tradeFunc(testAmount, {
-                                            sourceTokenAddress: reserveToken2.address
-                                        });
-                                        await expect(res1).to.be.revertedWith('InvalidToken');
+                                        await expect(
+                                            tradeFunc(testAmount, { sourceTokenAddress: reserveToken2.address })
+                                        ).to.be.revertedWith('InvalidToken');
 
                                         // unknown target token
-                                        const { res: res2 } = await tradeFunc(testAmount, {
-                                            targetTokenAddress: reserveToken2.address
-                                        });
-                                        await expect(res2).to.be.revertedWith('InvalidToken');
+                                        await expect(
+                                            tradeFunc(testAmount, { targetTokenAddress: reserveToken2.address })
+                                        ).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should revert when attempting to trade using same source and target tokens', async () => {
-                                        const { res } = await tradeFunc(testAmount, {
-                                            targetTokenAddress: sourceToken.address
-                                        });
-                                        await expect(res).to.be.revertedWith('InvalidToken');
+                                        await expect(
+                                            tradeFunc(testAmount, { targetTokenAddress: sourceToken.address })
+                                        ).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should support a custom beneficiary', async () => {
@@ -2786,12 +2688,11 @@ describe('BancorNetwork', () => {
                                                 if (permitted) {
                                                     // perform a permitted trade while signing a permit over an amount lower
                                                     // than the required amount
-                                                    const { res } = await tradeBySourceAmountPermittedFunc(testAmount, {
-                                                        approvedAmount: sourceAmount.sub(missingAmount)
-                                                    });
-                                                    await expect(res).to.be.revertedWith(
-                                                        'ERC20Permit: invalid signature'
-                                                    );
+                                                    await expect(
+                                                        tradeBySourceAmountPermittedFunc(testAmount, {
+                                                            approvedAmount: sourceAmount.sub(missingAmount)
+                                                        })
+                                                    ).to.be.revertedWith('ERC20Permit: invalid signature');
                                                 } else {
                                                     // reduce the approved amount and perform a trade by providing the source
                                                     // amount
@@ -2803,8 +2704,7 @@ describe('BancorNetwork', () => {
                                                         .connect(trader)
                                                         .approve(network.address, sourceAmount.sub(missingAmount));
 
-                                                    const { res } = await tradeFunc(testAmount);
-                                                    await expect(res).to.be.revertedWith(
+                                                    await expect(tradeFunc(testAmount)).to.be.revertedWith(
                                                         source.tokenData.errors().exceedsAllowance
                                                     );
                                                 }
@@ -2818,8 +2718,7 @@ describe('BancorNetwork', () => {
                                         });
 
                                         it('should revert when attempting to trade', async () => {
-                                            const { res } = await tradeFunc(testAmount);
-                                            await expect(res).to.be.revertedWith('Pausable: paused');
+                                            await expect(tradeFunc(testAmount)).to.be.revertedWith('Pausable: paused');
                                         });
                                     });
                                 });
@@ -2896,8 +2795,7 @@ describe('BancorNetwork', () => {
 
                             if (isSourceNativeToken || isSourceBNT) {
                                 it('should revert when attempting a permitted trade', async () => {
-                                    const { res } = await tradeFunc(amount);
-                                    await expect(res).to.be.revertedWith(
+                                    await expect(tradeFunc(amount)).to.be.revertedWith(
                                         isSourceNativeToken ? 'PermitUnsupported' : ''
                                     );
                                 });

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2117,7 +2117,7 @@ describe('BancorNetwork', () => {
             targetTokenAddress?: string;
         }
 
-        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
+        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, getRetVal = false) => {
             let {
                 value,
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
@@ -2129,22 +2129,42 @@ describe('BancorNetwork', () => {
 
             value ||= sourceTokenAddress === NATIVE_TOKEN_ADDRESS ? amount : BigNumber.from(0);
 
-            return network
-                .connect(trader)
-                .tradeBySourceAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            let retVal = BigNumber.from(0);
+            if (getRetVal) {
+                retVal = await network
+                    .connect(trader)
+                    .callStatic.tradeBySourceAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    );
+            }
+
+            return {
+                retVal,
+                res: network
+                    .connect(trader)
+                    .tradeBySourceAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    )
+            };
         };
 
-        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
+        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, getRetVal = false) => {
             let {
                 value,
                 limit: maxSourceAmount,
@@ -2171,19 +2191,39 @@ describe('BancorNetwork', () => {
                 }
             }
 
-            return network
-                .connect(trader)
-                .tradeByTargetAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            let retVal = BigNumber.from(0);
+            if (getRetVal) {
+                retVal = await network
+                    .connect(trader)
+                    .callStatic.tradeByTargetAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    );
+            }
+
+            return {
+                retVal,
+                res: network
+                    .connect(trader)
+                    .tradeByTargetAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    )
+            };
         };
 
         interface TradePermittedOverrides {
@@ -2195,7 +2235,11 @@ describe('BancorNetwork', () => {
             approvedAmount?: BigNumberish;
         }
 
-        const tradeBySourceAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
+        const tradeBySourceAmountPermitted = async (
+            amount: BigNumberish,
+            overrides: TradePermittedOverrides = {},
+            getRetVal = false
+        ) => {
             const {
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
                 deadline = MAX_UINT256,
@@ -2207,22 +2251,46 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return network
-                .connect(trader)
-                .tradeBySourceAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            let retVal = BigNumber.from(0);
+            if (getRetVal) {
+                retVal = await network
+                    .connect(trader)
+                    .callStatic.tradeBySourceAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    );
+            }
+
+            return {
+                retVal,
+                res: network
+                    .connect(trader)
+                    .tradeBySourceAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    )
+            };
         };
 
-        const tradeByTargetAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
+        const tradeByTargetAmountPermitted = async (
+            amount: BigNumberish,
+            overrides: TradePermittedOverrides = {},
+            getRetVal = false
+        ) => {
             let {
                 limit: maxSourceAmount,
                 deadline = MAX_UINT256,
@@ -2242,19 +2310,39 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return network
-                .connect(trader)
-                .tradeByTargetAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            let retVal = BigNumber.from(0);
+            if (getRetVal) {
+                retVal = await network
+                    .connect(trader)
+                    .callStatic.tradeByTargetAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    );
+            }
+
+            return {
+                retVal,
+                res: network
+                    .connect(trader)
+                    .tradeByTargetAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    )
+            };
         };
 
         const verifyTrade = async (
@@ -2263,8 +2351,9 @@ describe('BancorNetwork', () => {
             amount: BigNumberish,
             tradeFunc: (
                 amount: BigNumberish,
-                options: TradeOverrides | TradePermittedOverrides
-            ) => Promise<ContractTransaction>
+                options: TradeOverrides | TradePermittedOverrides,
+                getRetVal: boolean
+            ) => Promise<{ retVal: BigNumber; res: Promise<ContractTransaction> }>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;
             const isTargetNativeToken = targetToken.address === NATIVE_TOKEN_ADDRESS;
@@ -2394,13 +2483,19 @@ describe('BancorNetwork', () => {
                 pendingNetworkFeeAmount = pendingNetworkFeeAmount.add(hop1.networkFeeAmount.add(hop2.networkFeeAmount));
             }
 
-            const res = await tradeFunc(amount, {
-                limit,
-                beneficiary: beneficiaryAddress,
-                deadline
-            });
+            const { retVal, res } = await tradeFunc(
+                amount,
+                {
+                    limit,
+                    beneficiary: beneficiaryAddress,
+                    deadline
+                },
+                true
+            );
 
-            const transactionCost = await getTransactionCost(res);
+            expect(retVal).to.equal(hop2.amount);
+
+            const transactionCost = await getTransactionCost(await res);
 
             const contextId = solidityKeccak256(
                 ['address', 'uint32', 'address', 'address', 'uint256', 'uint256', 'bool', 'uint256', 'address'],
@@ -2581,11 +2676,11 @@ describe('BancorNetwork', () => {
                                     const extraAmount = 100_000;
                                     const prevTraderBalance = await getBalance(sourceToken, trader);
 
-                                    const res = await tradeDirectFunc(testAmount, {
+                                    const { res } = await tradeDirectFunc(testAmount, {
                                         value: sourceAmount.add(extraAmount)
                                     });
 
-                                    const transactionCost = await getTransactionCost(res);
+                                    const transactionCost = await getTransactionCost(await res);
 
                                     expect(await getBalance(sourceToken, trader)).equal(
                                         prevTraderBalance.sub(sourceAmount).sub(transactionCost)
@@ -3139,16 +3234,8 @@ describe('BancorNetwork', () => {
         });
 
         beforeEach(async () => {
-            ({
-                bntGovernance,
-                vbntGovernance,
-                network,
-                networkSettings,
-                bnt,
-                vbnt,
-                poolCollection,
-                masterVault
-            } = await createSystem());
+            ({ bntGovernance, vbntGovernance, network, networkSettings, bnt, vbnt, poolCollection, masterVault } =
+                await createSystem());
 
             await networkSettings.setWithdrawalFeePPM(WITHDRAWAL_FEE);
             await networkSettings.setMinLiquidityForTrading(MIN_LIQUIDITY_FOR_TRADING);

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2117,7 +2117,11 @@ describe('BancorNetwork', () => {
             targetTokenAddress?: string;
         }
 
-        const tradeBySourceAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, callStatic = false) => {
+        const tradeBySourceAmount = async (
+            amount: BigNumberish,
+            overrides: TradeOverrides = {},
+            callStatic = false
+        ) => {
             let {
                 value,
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
@@ -2131,21 +2135,24 @@ describe('BancorNetwork', () => {
 
             const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller
-                .tradeBySourceAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            return caller.tradeBySourceAmount(
+                sourceTokenAddress,
+                targetTokenAddress,
+                amount,
+                minReturnAmount,
+                deadline,
+                beneficiary,
+                {
+                    value
+                }
+            );
         };
 
-        const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}, callStatic = false) => {
+        const tradeByTargetAmount = async (
+            amount: BigNumberish,
+            overrides: TradeOverrides = {},
+            callStatic = false
+        ) => {
             let {
                 value,
                 limit: maxSourceAmount,
@@ -2174,18 +2181,17 @@ describe('BancorNetwork', () => {
 
             const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller
-                .tradeByTargetAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            return caller.tradeByTargetAmount(
+                sourceTokenAddress,
+                targetTokenAddress,
+                amount,
+                maxSourceAmount,
+                deadline,
+                beneficiary,
+                {
+                    value
+                }
+            );
         };
 
         interface TradePermittedOverrides {
@@ -2197,7 +2203,11 @@ describe('BancorNetwork', () => {
             approvedAmount?: BigNumberish;
         }
 
-        const tradeBySourceAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}, callStatic = false) => {
+        const tradeBySourceAmountPermitted = async (
+            amount: BigNumberish,
+            overrides: TradePermittedOverrides = {},
+            callStatic = false
+        ) => {
             const {
                 limit: minReturnAmount = MIN_RETURN_AMOUNT,
                 deadline = MAX_UINT256,
@@ -2211,21 +2221,24 @@ describe('BancorNetwork', () => {
 
             const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller
-                .tradeBySourceAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            return caller.tradeBySourceAmountPermitted(
+                sourceTokenAddress,
+                targetTokenAddress,
+                amount,
+                minReturnAmount,
+                deadline,
+                beneficiary,
+                signature.v,
+                signature.r,
+                signature.s
+            );
         };
 
-        const tradeByTargetAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}, callStatic = false) => {
+        const tradeByTargetAmountPermitted = async (
+            amount: BigNumberish,
+            overrides: TradePermittedOverrides = {},
+            callStatic = false
+        ) => {
             let {
                 limit: maxSourceAmount,
                 deadline = MAX_UINT256,
@@ -2247,18 +2260,17 @@ describe('BancorNetwork', () => {
 
             const caller = callStatic ? network.connect(trader).callStatic : network.connect(trader);
 
-            return caller
-                .tradeByTargetAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            return caller.tradeByTargetAmountPermitted(
+                sourceTokenAddress,
+                targetTokenAddress,
+                amount,
+                maxSourceAmount,
+                deadline,
+                beneficiary,
+                signature.v,
+                signature.r,
+                signature.s
+            );
         };
 
         const verifyTrade = async (
@@ -2399,19 +2411,27 @@ describe('BancorNetwork', () => {
                 pendingNetworkFeeAmount = pendingNetworkFeeAmount.add(hop1.networkFeeAmount.add(hop2.networkFeeAmount));
             }
 
-            const retVal = await tradeFunc(amount, {
-                limit,
-                beneficiary: beneficiaryAddress,
-                deadline,
-            }, true);
+            const retVal = await tradeFunc(
+                amount,
+                {
+                    limit,
+                    beneficiary: beneficiaryAddress,
+                    deadline
+                },
+                true
+            );
 
             expect(retVal).to.equal(hop2.amount);
 
-            const res = await tradeFunc(amount, {
-                limit,
-                beneficiary: beneficiaryAddress,
-                deadline,
-            }, false);
+            const res = await tradeFunc(
+                amount,
+                {
+                    limit,
+                    beneficiary: beneficiaryAddress,
+                    deadline
+                },
+                false
+            );
 
             const transactionCost = await getTransactionCost(res as ContractTransaction);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2705,31 +2705,31 @@ describe('BancorNetwork', () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             sourceTokenAddress: ZERO_ADDRESS
                                         });
-                                        await expect(await res).to.be.revertedWith('InvalidAddress');
+                                        await expect(res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid target token', async () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             targetTokenAddress: ZERO_ADDRESS
                                         });
-                                        await expect(await res).to.be.revertedWith('InvalidAddress');
+                                        await expect(res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid amount', async () => {
                                         const { res } = await tradeFunc(BigNumber.from(0));
-                                        await expect(await res).to.be.revertedWith('ZeroValue');
+                                        await expect(res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an invalid limit', async () => {
                                         const { res } = await tradeFunc(testAmount, { limit: BigNumber.from(0) });
-                                        await expect(await res).to.be.revertedWith('ZeroValue');
+                                        await expect(res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an expired deadline', async () => {
                                         const deadline = (await latest()) - 1000;
 
                                         const { res } = await tradeFunc(testAmount, { deadline });
-                                        await expect(await res).to.be.revertedWith('DeadlineExpired');
+                                        await expect(res).to.be.revertedWith('DeadlineExpired');
                                     });
 
                                     it('should revert when attempting to trade unsupported tokens', async () => {
@@ -2744,20 +2744,20 @@ describe('BancorNetwork', () => {
                                         const { res: res1 } = await tradeFunc(testAmount, {
                                             sourceTokenAddress: reserveToken2.address
                                         });
-                                        await expect(await res1).to.be.revertedWith('InvalidToken');
+                                        await expect(res1).to.be.revertedWith('InvalidToken');
 
                                         // unknown target token
                                         const { res: res2 } = await tradeFunc(testAmount, {
                                             targetTokenAddress: reserveToken2.address
                                         });
-                                        await expect(await res2).to.be.revertedWith('InvalidToken');
+                                        await expect(res2).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should revert when attempting to trade using same source and target tokens', async () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             targetTokenAddress: sourceToken.address
                                         });
-                                        await expect(await res).to.be.revertedWith('InvalidToken');
+                                        await expect(res).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should support a custom beneficiary', async () => {
@@ -2789,7 +2789,7 @@ describe('BancorNetwork', () => {
                                                     const { res } = await tradeBySourceAmountPermittedFunc(testAmount, {
                                                         approvedAmount: sourceAmount.sub(missingAmount)
                                                     });
-                                                    await expect(await res).to.be.revertedWith(
+                                                    await expect(res).to.be.revertedWith(
                                                         'ERC20Permit: invalid signature'
                                                     );
                                                 } else {
@@ -2804,7 +2804,7 @@ describe('BancorNetwork', () => {
                                                         .approve(network.address, sourceAmount.sub(missingAmount));
 
                                                     const { res } = await tradeFunc(testAmount);
-                                                    await expect(await res).to.be.revertedWith(
+                                                    await expect(res).to.be.revertedWith(
                                                         source.tokenData.errors().exceedsAllowance
                                                     );
                                                 }
@@ -2819,7 +2819,7 @@ describe('BancorNetwork', () => {
 
                                         it('should revert when attempting to trade', async () => {
                                             const { res } = await tradeFunc(testAmount);
-                                            await expect(await res).to.be.revertedWith('Pausable: paused');
+                                            await expect(res).to.be.revertedWith('Pausable: paused');
                                         });
                                     });
                                 });
@@ -2897,7 +2897,7 @@ describe('BancorNetwork', () => {
                             if (isSourceNativeToken || isSourceBNT) {
                                 it('should revert when attempting a permitted trade', async () => {
                                     const { res } = await tradeFunc(amount);
-                                    await expect(await res).to.be.revertedWith(
+                                    await expect(res).to.be.revertedWith(
                                         isSourceNativeToken ? 'PermitUnsupported' : ''
                                     );
                                 });

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2129,19 +2129,34 @@ describe('BancorNetwork', () => {
 
             value ||= sourceTokenAddress === NATIVE_TOKEN_ADDRESS ? amount : BigNumber.from(0);
 
-            return network
-                .connect(trader)
-                .tradeBySourceAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            return {
+                val: await network
+                    .connect(trader)
+                    .callStatic.tradeBySourceAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    ),
+                res: await network
+                    .connect(trader)
+                    .tradeBySourceAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    )
+            };
         };
 
         const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
@@ -2171,19 +2186,34 @@ describe('BancorNetwork', () => {
                 }
             }
 
-            return network
-                .connect(trader)
-                .tradeByTargetAmount(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    {
-                        value
-                    }
-                );
+            return {
+                val: await network
+                    .connect(trader)
+                    .callStatic.tradeByTargetAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    ),
+                res: await network
+                    .connect(trader)
+                    .tradeByTargetAmount(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        {
+                            value
+                        }
+                    )
+            };
         };
 
         interface TradePermittedOverrides {
@@ -2207,19 +2237,34 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return network
-                .connect(trader)
-                .tradeBySourceAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    minReturnAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            return {
+                val: await network
+                    .connect(trader)
+                    .callStatic.tradeBySourceAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    ),
+                res: await network
+                    .connect(trader)
+                    .tradeBySourceAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        minReturnAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    )
+            };
         };
 
         const tradeByTargetAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
@@ -2242,19 +2287,34 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return network
-                .connect(trader)
-                .tradeByTargetAmountPermitted(
-                    sourceTokenAddress,
-                    targetTokenAddress,
-                    amount,
-                    maxSourceAmount,
-                    deadline,
-                    beneficiary,
-                    signature.v,
-                    signature.r,
-                    signature.s
-                );
+            return {
+                val: await network
+                    .connect(trader)
+                    .callStatic.tradeByTargetAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    ),
+                res: await network
+                    .connect(trader)
+                    .tradeByTargetAmountPermitted(
+                        sourceTokenAddress,
+                        targetTokenAddress,
+                        amount,
+                        maxSourceAmount,
+                        deadline,
+                        beneficiary,
+                        signature.v,
+                        signature.r,
+                        signature.s
+                    )
+            };
         };
 
         const verifyTrade = async (
@@ -2264,7 +2324,7 @@ describe('BancorNetwork', () => {
             tradeFunc: (
                 amount: BigNumberish,
                 options: TradeOverrides | TradePermittedOverrides
-            ) => Promise<ContractTransaction>
+            ) => Promise<{ val: BigNumber; res: ContractTransaction }>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;
             const isTargetNativeToken = targetToken.address === NATIVE_TOKEN_ADDRESS;
@@ -2394,11 +2454,13 @@ describe('BancorNetwork', () => {
                 pendingNetworkFeeAmount = pendingNetworkFeeAmount.add(hop1.networkFeeAmount.add(hop2.networkFeeAmount));
             }
 
-            const res = await tradeFunc(amount, {
+            const { val, res } = await tradeFunc(amount, {
                 limit,
                 beneficiary: beneficiaryAddress,
                 deadline
             });
+
+            expect(val).to.equal(hop2.amount);
 
             const transactionCost = await getTransactionCost(res);
 
@@ -2581,7 +2643,7 @@ describe('BancorNetwork', () => {
                                     const extraAmount = 100_000;
                                     const prevTraderBalance = await getBalance(sourceToken, trader);
 
-                                    const res = await tradeDirectFunc(testAmount, {
+                                    const { res } = await tradeDirectFunc(testAmount, {
                                         value: sourceAmount.add(extraAmount)
                                     });
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2045,7 +2045,7 @@ describe('BancorNetwork', () => {
         }
     });
 
-    describe.only('trade', () => {
+    describe('trade', () => {
         let network: TestBancorNetwork;
         let networkInfo: BancorNetworkInfo;
         let networkSettings: NetworkSettings;

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3040,10 +3040,10 @@ describe('BancorNetwork', () => {
 
                 const data = '0x1234';
 
-                const val = network.callStatic.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
+                const val = await network.callStatic.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
                 expect(val).to.equal(FEE_AMOUNT);
 
-                const res = network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
+                const res = await network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
 
                 await expect(res)
                     .to.emit(network, 'FlashLoanCompleted')

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2705,31 +2705,31 @@ describe('BancorNetwork', () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             sourceTokenAddress: ZERO_ADDRESS
                                         });
-                                        await expect(res).to.be.revertedWith('InvalidAddress');
+                                        await expect(await res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid target token', async () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             targetTokenAddress: ZERO_ADDRESS
                                         });
-                                        await expect(res).to.be.revertedWith('InvalidAddress');
+                                        await expect(await res).to.be.revertedWith('InvalidAddress');
                                     });
 
                                     it('should revert when attempting to trade using an invalid amount', async () => {
                                         const { res } = await tradeFunc(BigNumber.from(0));
-                                        await expect(res).to.be.revertedWith('ZeroValue');
+                                        await expect(await res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an invalid limit', async () => {
                                         const { res } = await tradeFunc(testAmount, { limit: BigNumber.from(0) });
-                                        await expect(res).to.be.revertedWith('ZeroValue');
+                                        await expect(await res).to.be.revertedWith('ZeroValue');
                                     });
 
                                     it('should revert when attempting to trade using an expired deadline', async () => {
                                         const deadline = (await latest()) - 1000;
 
                                         const { res } = await tradeFunc(testAmount, { deadline });
-                                        await expect(res).to.be.revertedWith('DeadlineExpired');
+                                        await expect(await res).to.be.revertedWith('DeadlineExpired');
                                     });
 
                                     it('should revert when attempting to trade unsupported tokens', async () => {
@@ -2744,20 +2744,20 @@ describe('BancorNetwork', () => {
                                         const { res: res1 } = await tradeFunc(testAmount, {
                                             sourceTokenAddress: reserveToken2.address
                                         });
-                                        await expect(res1).to.be.revertedWith('InvalidToken');
+                                        await expect(await res1).to.be.revertedWith('InvalidToken');
 
                                         // unknown target token
                                         const { res: res2 } = await tradeFunc(testAmount, {
                                             targetTokenAddress: reserveToken2.address
                                         });
-                                        await expect(res2).to.be.revertedWith('InvalidToken');
+                                        await expect(await res2).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should revert when attempting to trade using same source and target tokens', async () => {
                                         const { res } = await tradeFunc(testAmount, {
                                             targetTokenAddress: sourceToken.address
                                         });
-                                        await expect(res).to.be.revertedWith('InvalidToken');
+                                        await expect(await res).to.be.revertedWith('InvalidToken');
                                     });
 
                                     it('should support a custom beneficiary', async () => {
@@ -2789,7 +2789,7 @@ describe('BancorNetwork', () => {
                                                     const { res } = await tradeBySourceAmountPermittedFunc(testAmount, {
                                                         approvedAmount: sourceAmount.sub(missingAmount)
                                                     });
-                                                    await expect(res).to.be.revertedWith(
+                                                    await expect(await res).to.be.revertedWith(
                                                         'ERC20Permit: invalid signature'
                                                     );
                                                 } else {
@@ -2804,7 +2804,7 @@ describe('BancorNetwork', () => {
                                                         .approve(network.address, sourceAmount.sub(missingAmount));
 
                                                     const { res } = await tradeFunc(testAmount);
-                                                    await expect(res).to.be.revertedWith(
+                                                    await expect(await res).to.be.revertedWith(
                                                         source.tokenData.errors().exceedsAllowance
                                                     );
                                                 }
@@ -2819,7 +2819,7 @@ describe('BancorNetwork', () => {
 
                                         it('should revert when attempting to trade', async () => {
                                             const { res } = await tradeFunc(testAmount);
-                                            await expect(res).to.be.revertedWith('Pausable: paused');
+                                            await expect(await res).to.be.revertedWith('Pausable: paused');
                                         });
                                     });
                                 });
@@ -2897,7 +2897,7 @@ describe('BancorNetwork', () => {
                             if (isSourceNativeToken || isSourceBNT) {
                                 it('should revert when attempting a permitted trade', async () => {
                                     const { res } = await tradeFunc(amount);
-                                    await expect(res).to.be.revertedWith(
+                                    await expect(await res).to.be.revertedWith(
                                         isSourceNativeToken ? 'PermitUnsupported' : ''
                                     );
                                 });

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3856,6 +3856,10 @@ describe('BancorNetwork', () => {
             });
 
             it('should cancel a pending withdrawal request', async () => {
+                const withdrawalRequest = await pendingWithdrawals.withdrawalRequest(id);
+                const val = await network.connect(provider).callStatic.cancelWithdrawal(id);
+                expect(val).to.equal(withdrawalRequest.reserveTokenAmount);
+
                 await network.connect(provider).cancelWithdrawal(id);
 
                 const withdrawalRequestIds = await pendingWithdrawals.withdrawalRequestIds(provider.address);
@@ -3931,7 +3935,9 @@ describe('BancorNetwork', () => {
             it('should not withdraw any pending network fees', async () => {
                 const prevBNTBalance = await bnt.balanceOf(networkFeeManager.address);
 
-                const val = await network.connect(networkFeeManager).callStatic.withdrawNetworkFees(networkFeeManager.address);
+                const val = await network
+                    .connect(networkFeeManager)
+                    .callStatic.withdrawNetworkFees(networkFeeManager.address);
                 expect(val).to.equal(0);
 
                 const res = await network.connect(networkFeeManager).withdrawNetworkFees(networkFeeManager.address);

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3040,6 +3040,9 @@ describe('BancorNetwork', () => {
 
                 const data = '0x1234';
 
+                const val = network.callStatic.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
+                expect(val).to.equal(FEE_AMOUNT);
+
                 const res = network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
 
                 await expect(res)

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2281,7 +2281,7 @@ describe('BancorNetwork', () => {
                 amount: BigNumberish,
                 options: TradeOverrides | TradePermittedOverrides,
                 callStatic: boolean
-            ) => Promise<ContractTransaction | BigNumber>
+            ) => Promise<ContractTransaction | BigNumber | void>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;
             const isTargetNativeToken = targetToken.address === NATIVE_TOKEN_ADDRESS;
@@ -3072,14 +3072,6 @@ describe('BancorNetwork', () => {
                 const prevBNTBalance = await getBalance(token, network.address);
 
                 const data = '0x1234';
-
-                const feeAmount = await network.callStatic.flashLoan(
-                    token.address,
-                    LOAN_AMOUNT,
-                    recipient.address,
-                    data
-                );
-                expect(feeAmount).to.equal(FEE_AMOUNT);
 
                 const res = await network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, data);
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3188,14 +3188,11 @@ describe('BancorNetwork', () => {
         let bntGovernance: TokenGovernance;
         let vbntGovernance: TokenGovernance;
         let network: TestBancorNetwork;
-        let networkInfo: BancorNetworkInfo;
         let networkSettings: NetworkSettings;
         let bnt: IERC20;
         let vbnt: IERC20;
         let poolCollection: TestPoolCollection;
         let masterVault: MasterVault;
-        let bntPoolToken: PoolToken;
-        let bntPool: TestBNTPool;
 
         let emergencyStopper: SignerWithAddress;
 
@@ -3208,14 +3205,11 @@ describe('BancorNetwork', () => {
                 bntGovernance,
                 vbntGovernance,
                 network,
-                networkInfo,
                 networkSettings,
                 bnt,
                 vbnt,
                 poolCollection,
-                masterVault,
-                bntPoolToken,
-                bntPool
+                masterVault
             } = await createSystem());
 
             await networkSettings.setWithdrawalFeePPM(WITHDRAWAL_FEE);
@@ -3430,18 +3424,6 @@ describe('BancorNetwork', () => {
                             await baseToken.approve(network.address, MAX_UINT256);
                         }
 
-                        const newPoolToken = await Contracts.PoolToken.attach(
-                            await networkInfo.poolToken(baseToken.address)
-                        );
-                        const prevTotalSupply = await newPoolToken.totalSupply();
-                        const poolTokenAmount = await network.callStatic.migrateLiquidity(
-                            baseToken.address,
-                            deployer.address,
-                            amount,
-                            availableAmount,
-                            originalAmount,
-                            { value }
-                        );
                         const res = await network.migrateLiquidity(
                             baseToken.address,
                             deployer.address,
@@ -3450,8 +3432,6 @@ describe('BancorNetwork', () => {
                             originalAmount,
                             { value }
                         );
-                        const currTotalSupply = await newPoolToken.totalSupply();
-                        expect(currTotalSupply).to.equal(prevTotalSupply.add(poolTokenAmount));
 
                         await expect(res)
                             .to.emit(network, 'FundsMigrated')
@@ -3648,14 +3628,6 @@ describe('BancorNetwork', () => {
                     await poolToken.approve(network.address, MAX_UINT256);
                     await baseToken.approve(network.address, MAX_UINT256);
 
-                    const prevProtocolBalance = await bntPoolToken.balanceOf(bntPool.address);
-                    const poolTokenAmount = await network.callStatic.migrateLiquidity(
-                        bnt.address,
-                        deployer.address,
-                        amount,
-                        availableAmount,
-                        originalAmount
-                    );
                     const res = await network.migrateLiquidity(
                         bnt.address,
                         deployer.address,
@@ -3663,8 +3635,6 @@ describe('BancorNetwork', () => {
                         availableAmount,
                         originalAmount
                     );
-                    const currProtocolBalance = await bntPoolToken.balanceOf(bntPool.address);
-                    expect(currProtocolBalance).to.equal(prevProtocolBalance.sub(poolTokenAmount));
 
                     await expect(res)
                         .to.emit(network, 'FundsMigrated')

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -2129,34 +2129,19 @@ describe('BancorNetwork', () => {
 
             value ||= sourceTokenAddress === NATIVE_TOKEN_ADDRESS ? amount : BigNumber.from(0);
 
-            return {
-                val: await network
-                    .connect(trader)
-                    .callStatic.tradeBySourceAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    ),
-                res: await network
-                    .connect(trader)
-                    .tradeBySourceAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeBySourceAmount(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    minReturnAmount,
+                    deadline,
+                    beneficiary,
+                    {
+                        value
+                    }
+                );
         };
 
         const tradeByTargetAmount = async (amount: BigNumberish, overrides: TradeOverrides = {}) => {
@@ -2186,34 +2171,19 @@ describe('BancorNetwork', () => {
                 }
             }
 
-            return {
-                val: await network
-                    .connect(trader)
-                    .callStatic.tradeByTargetAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    ),
-                res: await network
-                    .connect(trader)
-                    .tradeByTargetAmount(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        {
-                            value
-                        }
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeByTargetAmount(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    maxSourceAmount,
+                    deadline,
+                    beneficiary,
+                    {
+                        value
+                    }
+                );
         };
 
         interface TradePermittedOverrides {
@@ -2237,34 +2207,19 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return {
-                val: await network
-                    .connect(trader)
-                    .callStatic.tradeBySourceAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    ),
-                res: await network
-                    .connect(trader)
-                    .tradeBySourceAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        minReturnAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeBySourceAmountPermitted(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    minReturnAmount,
+                    deadline,
+                    beneficiary,
+                    signature.v,
+                    signature.r,
+                    signature.s
+                );
         };
 
         const tradeByTargetAmountPermitted = async (amount: BigNumberish, overrides: TradePermittedOverrides = {}) => {
@@ -2287,34 +2242,19 @@ describe('BancorNetwork', () => {
 
             const signature = await permitSignature(trader, sourceTokenAddress, network, bnt, approvedAmount, deadline);
 
-            return {
-                val: await network
-                    .connect(trader)
-                    .callStatic.tradeByTargetAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    ),
-                res: await network
-                    .connect(trader)
-                    .tradeByTargetAmountPermitted(
-                        sourceTokenAddress,
-                        targetTokenAddress,
-                        amount,
-                        maxSourceAmount,
-                        deadline,
-                        beneficiary,
-                        signature.v,
-                        signature.r,
-                        signature.s
-                    )
-            };
+            return network
+                .connect(trader)
+                .tradeByTargetAmountPermitted(
+                    sourceTokenAddress,
+                    targetTokenAddress,
+                    amount,
+                    maxSourceAmount,
+                    deadline,
+                    beneficiary,
+                    signature.v,
+                    signature.r,
+                    signature.s
+                );
         };
 
         const verifyTrade = async (
@@ -2324,7 +2264,7 @@ describe('BancorNetwork', () => {
             tradeFunc: (
                 amount: BigNumberish,
                 options: TradeOverrides | TradePermittedOverrides
-            ) => Promise<{ val: BigNumber; res: ContractTransaction }>
+            ) => Promise<ContractTransaction>
         ) => {
             const isSourceNativeToken = sourceToken.address === NATIVE_TOKEN_ADDRESS;
             const isTargetNativeToken = targetToken.address === NATIVE_TOKEN_ADDRESS;
@@ -2454,13 +2394,11 @@ describe('BancorNetwork', () => {
                 pendingNetworkFeeAmount = pendingNetworkFeeAmount.add(hop1.networkFeeAmount.add(hop2.networkFeeAmount));
             }
 
-            const { val, res } = await tradeFunc(amount, {
+            const res = await tradeFunc(amount, {
                 limit,
                 beneficiary: beneficiaryAddress,
                 deadline
             });
-
-            expect(val).to.equal(hop2.amount);
 
             const transactionCost = await getTransactionCost(res);
 
@@ -2643,7 +2581,7 @@ describe('BancorNetwork', () => {
                                     const extraAmount = 100_000;
                                     const prevTraderBalance = await getBalance(sourceToken, trader);
 
-                                    const { res } = await tradeDirectFunc(testAmount, {
+                                    const res = await tradeDirectFunc(testAmount, {
                                         value: sourceAmount.add(extraAmount)
                                     });
 

--- a/test/network/PendingWithdrawals.ts
+++ b/test/network/PendingWithdrawals.ts
@@ -341,8 +341,8 @@ describe('PendingWithdrawals', () => {
                         );
                         const withdrawalRequest = await pendingWithdrawals.withdrawalRequest(id);
 
-                        const val = await network.connect(provider).callStatic.cancelWithdrawal(id);
-                        expect(val).to.equal(withdrawalRequest.reserveTokenAmount);
+                        const poolTokenAmount = await network.connect(provider).callStatic.cancelWithdrawal(id);
+                        expect(poolTokenAmount).to.equal(withdrawalRequest.poolTokenAmount);
 
                         const res = await network.connect(provider).cancelWithdrawal(id);
                         await expect(res)

--- a/test/network/PendingWithdrawals.ts
+++ b/test/network/PendingWithdrawals.ts
@@ -341,6 +341,9 @@ describe('PendingWithdrawals', () => {
                         );
                         const withdrawalRequest = await pendingWithdrawals.withdrawalRequest(id);
 
+                        const val = await network.connect(provider).callStatic.cancelWithdrawal(id);
+                        expect(val).to.equal(withdrawalRequest.reserveTokenAmount);
+
                         const res = await network.connect(provider).cancelWithdrawal(id);
                         await expect(res)
                             .to.emit(pendingWithdrawals, 'WithdrawalCancelled')


### PR DESCRIPTION
In contract `BancorNetwork`:
- Extend function `cancelWithdrawal` to return the value of the position in units of the reserve token
- Extend function `tradeBySourceAmount/Permitted` to return the trade target amount
- Extend function `tradeByTargetAmount/Permitted` to return the trade source amount
- Extend function `flashLoan` to return the amount of fee paid
- Extend function `withdrawNetworkFees` to return the amount of fees withdrawn
