### PR TITLE
Enable no-floating-promises and prefer-nullish-coalescing TypeScript linter rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,10 +29,20 @@
         "no-loop-func": "off",
         "no-unused-expressions": "off",
         "mocha/no-exclusive-tests": "error",
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off"
     },
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx"],
+            "parserOptions": {
+                "project": "./tsconfig.json"
+            }
+        }
+    ],
     "globals": {
         "assert": true,
         "expect": true,

--- a/components/ContractBuilder.ts
+++ b/components/ContractBuilder.ts
@@ -38,7 +38,7 @@ export const deployOrAttach = <F extends ContractFactory>(
             bytecode: FactoryConstructor.bytecode
         },
         deploy: async (...args: Parameters<F['deploy']>): Promise<Contract<F>> => {
-            const defaultSigner = initialSigner || (await ethers.getSigners())[0];
+            const defaultSigner = initialSigner ?? (await ethers.getSigners())[0];
 
             return new FactoryConstructor(defaultSigner).deploy(...(args || [])) as Promise<Contract<F>>;
         },
@@ -52,8 +52,8 @@ export const attachOnly = <F extends ContractFactory>(
 ) => {
     return {
         attach: async (address: string, signer?: Signer): Promise<Contract<F>> => {
-            const defaultSigner = initialSigner || (await ethers.getSigners())[0];
-            return new FactoryConstructor(signer || defaultSigner).attach(address) as Contract<F>;
+            const defaultSigner = initialSigner ?? (await ethers.getSigners())[0];
+            return new FactoryConstructor(signer ?? defaultSigner).attach(address) as Contract<F>;
         }
     };
 };

--- a/test/bancor-portal/BancorPortal.ts
+++ b/test/bancor-portal/BancorPortal.ts
@@ -145,7 +145,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken1, poolToken: poolToken1 },
                 { reserveToken: whitelistedToken2, poolToken: poolToken2 }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -316,7 +316,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken, poolToken },
                 { reserveToken: unlistedToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -339,7 +339,7 @@ describe('BancorPortal', () => {
                 { reserveToken: unlistedToken },
                 { reserveToken: whitelistedToken, poolToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -362,7 +362,7 @@ describe('BancorPortal', () => {
                 { reserveToken: token1, poolToken: poolToken1 },
                 { reserveToken: token2, poolToken: poolToken2 }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -385,7 +385,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken, poolToken },
                 { reserveToken: unlistedToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -408,7 +408,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken1, poolToken: poolToken1 },
                 { reserveToken: whitelistedToken2, poolToken: poolToken2 }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -431,7 +431,7 @@ describe('BancorPortal', () => {
                 { reserveToken: unlistedToken },
                 { reserveToken: whitelistedToken, poolToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -454,7 +454,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken1, poolToken: poolToken1 },
                 { reserveToken: whitelistedToken2, poolToken: poolToken2 }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -479,7 +479,7 @@ describe('BancorPortal', () => {
                 { reserveToken: bnt, poolToken: bntPoolToken },
                 { reserveToken: unlistedToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -504,7 +504,7 @@ describe('BancorPortal', () => {
                 { reserveToken: unlistedToken },
                 { reserveToken: bnt, poolToken: bntPoolToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -528,7 +528,7 @@ describe('BancorPortal', () => {
                 { reserveToken: bnt, poolToken: bntPoolToken },
                 { reserveToken: whitelistedToken, poolToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -552,7 +552,7 @@ describe('BancorPortal', () => {
                 { reserveToken: whitelistedToken, poolToken },
                 { reserveToken: bnt, poolToken: bntPoolToken }
             ]);
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'UniswapV2PositionMigrated')
                 .withArgs(
                     user.address,
@@ -583,7 +583,7 @@ describe('BancorPortal', () => {
                 [{ reserveToken: whitelistedToken, poolToken }, { reserveToken: unlistedToken }],
                 true
             );
-            expect(res)
+            await expect(res)
                 .to.emit(bancorPortal, 'SushiSwapV2PositionMigrated')
                 .withArgs(
                     user.address,

--- a/test/helpers/Deploy.ts
+++ b/test/helpers/Deploy.ts
@@ -9,17 +9,17 @@ interface Options {
     beforeDeployments?: () => Promise<void>;
 }
 
-export const describeDeployment = async (
+export const describeDeployment = (
     filename: string,
     fn: (this: Suite) => void,
     options: Options = {}
-): Promise<Suite | void> => {
+): Suite | void => {
     const { id, tag } = deploymentMetadata(filename);
 
     const { skip = () => false, beforeDeployments = () => Promise.resolve() } = options;
 
     // if we're running against a mainnet fork, ensure to skip tests for already existing deployments
-    if (skip() || (await deploymentTagExists(tag))) {
+    if (skip() || deploymentTagExists(tag)) {
         return describe.skip(id, fn);
     }
 

--- a/test/helpers/Factory.ts
+++ b/test/helpers/Factory.ts
@@ -460,7 +460,7 @@ const setupPool = async (
     const factory = isProfiling ? Contracts.TestGovernedToken : LegacyContracts.BNT;
     const bnt = await factory.attach(await networkInfo.bnt());
 
-    if (spec.token?.address === bnt.address ?? spec.tokenData.isBNT()) {
+    if (spec.token?.address === bnt.address || spec.tokenData.isBNT()) {
         const poolToken = await Contracts.PoolToken.attach(await networkInfo.poolToken(bnt.address));
 
         // ensure that there is enough space to deposit BNT

--- a/test/helpers/Factory.ts
+++ b/test/helpers/Factory.ts
@@ -59,7 +59,7 @@ export const proxyAdmin = async () => {
 
 const createLogic = async <F extends ContractFactory>(factory: ContractBuilder<F>, ctorArgs: CtorArgs = []) => {
     // eslint-disable-next-line @typescript-eslint/ban-types
-    return (factory.deploy as Function)(...(ctorArgs || []));
+    return (factory.deploy as Function)(...(ctorArgs ?? []));
 };
 
 const createTransparentProxy = async (
@@ -94,7 +94,7 @@ export const upgradeProxy = async <F extends ContractFactory>(
     await admin.upgradeAndCall(
         proxy.address,
         logicContract.address,
-        logicContract.interface.encodeFunctionData('postUpgrade', [args?.upgradeCallData || []])
+        logicContract.interface.encodeFunctionData('postUpgrade', [args?.upgradeCallData ?? []])
     );
 
     return factory.attach(proxy.address);
@@ -170,7 +170,7 @@ const createGovernedToken = async (
         token = testToken;
     } else {
         const legacyToken = await legacyFactory.deploy(name, symbol, decimals);
-        legacyToken.issue(deployer.address, totalSupply);
+        await legacyToken.issue(deployer.address, totalSupply);
 
         tokenGovernance = await LegacyContracts.TokenGovernance.deploy(legacyToken.address);
         await tokenGovernance.grantRole(Roles.TokenGovernance.ROLE_GOVERNOR, deployer.address);
@@ -460,7 +460,7 @@ const setupPool = async (
     const factory = isProfiling ? Contracts.TestGovernedToken : LegacyContracts.BNT;
     const bnt = await factory.attach(await networkInfo.bnt());
 
-    if (spec.token?.address === bnt.address || spec.tokenData.isBNT()) {
+    if (spec.token?.address === bnt.address ?? spec.tokenData.isBNT()) {
         const poolToken = await Contracts.PoolToken.attach(await networkInfo.poolToken(bnt.address));
 
         // ensure that there is enough space to deposit BNT
@@ -475,7 +475,7 @@ const setupPool = async (
         return { poolToken, token: bnt };
     }
 
-    const token = spec.token || (await createToken(spec.tokenData));
+    const token = spec.token ?? (await createToken(spec.tokenData));
     const poolToken = await createPool(token, network, networkSettings, poolCollection);
 
     await networkSettings.setFundingLimit(token.address, MAX_UINT256);

--- a/test/network/BancorNetworkInfo.ts
+++ b/test/network/BancorNetworkInfo.ts
@@ -592,7 +592,7 @@ describe('BancorNetworkInfo', () => {
     });
 
     describe('pool token calculations', () => {
-        const testPoolTokenCalculations = async (tokenData: TokenData) => {
+        const testPoolTokenCalculations = (tokenData: TokenData) => {
             let networkSettings: NetworkSettings;
             let network: TestBancorNetwork;
             let bnt: IERC20;

--- a/test/network/PendingWithdrawals.ts
+++ b/test/network/PendingWithdrawals.ts
@@ -146,7 +146,7 @@ describe('PendingWithdrawals', () => {
 
         const MIN_LIQUIDITY_FOR_TRADING = toWei(100_000);
 
-        const testWithdrawals = async (tokenData: TokenData) => {
+        const testWithdrawals = (tokenData: TokenData) => {
             beforeEach(async () => {
                 ({ network, networkInfo, networkSettings, bntPool, bntPoolToken, pendingWithdrawals, poolCollection } =
                     await createSystem());

--- a/test/network/Profile.ts
+++ b/test/network/Profile.ts
@@ -180,7 +180,7 @@ describe('Profile @profile', () => {
                                 }
                             };
 
-                            const testDepositAmount = async (amount: BigNumber) => {
+                            const testDepositAmount = (amount: BigNumber) => {
                                 const COUNT = 3;
 
                                 const testMultipleDeposits = async () => {
@@ -338,7 +338,7 @@ describe('Profile @profile', () => {
                                 }
                             };
 
-                            const testDepositAmount = async (amount: BigNumber) => {
+                            const testDepositAmount = (amount: BigNumber) => {
                                 const test = async () =>
                                     profiler.profile(`deposit ${tokenData.symbol()}`, deposit(amount));
 
@@ -428,7 +428,7 @@ describe('Profile @profile', () => {
             creationTime: number;
         }
 
-        const testWithdraw = async (tokenData: TokenData) => {
+        const testWithdraw = (tokenData: TokenData) => {
             let provider: SignerWithAddress;
             let poolToken: PoolToken;
             let token: TokenWithAddress;
@@ -1041,7 +1041,7 @@ describe('Profile @profile', () => {
             recipient = await Contracts.TestFlashLoanRecipient.deploy(network.address);
         });
 
-        const testFlashLoan = async (tokenData: TokenData, flashLoanFeePPM: number) => {
+        const testFlashLoan = (tokenData: TokenData, flashLoanFeePPM: number) => {
             const FEE_AMOUNT = LOAN_AMOUNT.mul(flashLoanFeePPM).div(PPM_RESOLUTION);
 
             beforeEach(async () => {

--- a/test/pools/PoolCollection.ts
+++ b/test/pools/PoolCollection.ts
@@ -647,7 +647,7 @@ describe('PoolCollection', () => {
             await networkSettings.setMinLiquidityForTrading(MIN_LIQUIDITY_FOR_TRADING);
         });
 
-        const testActivation = async (tokenData: TokenData) => {
+        const testActivation = (tokenData: TokenData) => {
             const testEnableTrading = async (totalLiquidity: BigNumber) => {
                 expect(await bntPool.currentPoolFunding(token.address)).to.equal(0);
 
@@ -854,7 +854,7 @@ describe('PoolCollection', () => {
             await networkSettings.setMinLiquidityForTrading(MIN_LIQUIDITY_FOR_TRADING);
         });
 
-        const testDisableTrading = async (tokenData: TokenData) => {
+        const testDisableTrading = (tokenData: TokenData) => {
             const testReset = async (expectedStakedBalance: BigNumberish) => {
                 const { tradingEnabled: prevTradingEnabled } = await poolCollection.poolData(token.address);
                 const res = await poolCollection.disableTrading(token.address);

--- a/test/rewards/StandardRewards.ts
+++ b/test/rewards/StandardRewards.ts
@@ -1948,7 +1948,7 @@ describe('StandardRewards', () => {
         };
 
         describe('claiming/staking', () => {
-            const testBasicClaiming = async (programSpec: ProgramSpec, rewardsSpec: RewardsSpec) => {
+            const testBasicClaiming = (programSpec: ProgramSpec, rewardsSpec: RewardsSpec) => {
                 describe('basic tests', () => {
                     let rewardsData: RewardsData;
                     let programData: ProgramData;

--- a/test/vaults/ExternalRewardsVault.ts
+++ b/test/vaults/ExternalRewardsVault.ts
@@ -94,7 +94,7 @@ describe('ExternalRewardsVault', () => {
 
                 token = tokenData.isBNT() ? bnt : await createTestToken();
 
-                transfer(deployer, token, externalRewardsVault.address, amount);
+                await transfer(deployer, token, externalRewardsVault.address, amount);
             });
 
             context(`withdrawing ${symbol}`, () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,29 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        "lib": ["dom", "esnext"],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "declaration": true,
-        "declarationMap": true,
-        "sourceMap": true,
-        "strict": true,
-        "esModuleInterop": true,
-        "baseUrl": "./",
-        "paths": {
-            "@nomiclabs/hardhat-ethers/*": ["node_modules/@nomiclabs/hardhat-ethers/dist/src/*"],
-            "*": ["node_modules/*"]
-        },
-        "outDir": "./dist"
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "esnext"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": "./",
+    "paths": {
+      "@nomiclabs/hardhat-ethers/*": ["node_modules/@nomiclabs/hardhat-ethers/dist/src/*"],
+      "*": ["node_modules/*"]
     },
-    "include": [
-        "./hardhat.config.ts",
-        "./typechain-types",
-        "./components",
-        "./utils",
-        "./test",
-        "./scripts",
-        "./deploy",
-        "./deployments/mainnet/types",
-
-    ]
+    "outDir": "./dist"
+  },
+  "include": [
+    "./hardhat.config.ts",
+    "./typechain-types",
+    "./components",
+    "./utils",
+    "./test",
+    "./scripts",
+    "./deploy",
+    "./deployments"
+  ]
 }

--- a/utils/Deploy.ts
+++ b/utils/Deploy.ts
@@ -230,7 +230,7 @@ interface DeleteForkOptions extends CreateForkOptions {
 export const deleteTenderlyFork = async (options: DeleteForkOptions = { projectName: TENDERLY_PROJECT }) =>
     axios.delete(
         `https://api.tenderly.co/api/v1/account/${TENDERLY_USERNAME}/project/${options.projectName}/fork/${
-            options.targetForkId || forkId
+            options.targetForkId ?? forkId
         }`,
         {
             headers: {
@@ -359,7 +359,7 @@ const WAIT_CONFIRMATIONS = isLive() ? 2 : 1;
 export const deploy = async (options: DeployOptions) => {
     const { name, contract, from, value, args, contractArtifactData, proxy } = options;
     const isProxy = !!proxy;
-    const contractName = contract || name;
+    const contractName = contract ?? name;
 
     await fundAccount(from);
 
@@ -383,7 +383,7 @@ export const deploy = async (options: DeployOptions) => {
     }
 
     const res = await deployContract(name, {
-        contract: contractArtifactData || contractName,
+        contract: contractArtifactData ?? contractName,
         from,
         value,
         args,
@@ -394,7 +394,7 @@ export const deploy = async (options: DeployOptions) => {
 
     if (!proxy || !proxy.skipInitialization) {
         const data = { name, contract: contractName };
-        saveTypes(data);
+        await saveTypes(data);
 
         await verifyTenderlyFork({
             address: res.address,
@@ -419,7 +419,7 @@ interface UpgradeProxyOptions extends DeployOptions {
 
 export const upgradeProxy = async (options: UpgradeProxyOptions) => {
     const { name, contract, from, value, args, upgradeArgs, contractArtifactData } = options;
-    const contractName = contract || name;
+    const contractName = contract ?? name;
 
     await fundAccount(from);
 
@@ -435,11 +435,11 @@ export const upgradeProxy = async (options: UpgradeProxyOptions) => {
         proxyContract: PROXY_CONTRACT,
         owner: await proxyAdmin.owner(),
         viaAdminContract: InstanceName.ProxyAdmin,
-        execute: { onUpgrade: { methodName: POST_UPGRADE, args: upgradeArgs || [ZERO_BYTES] } }
+        execute: { onUpgrade: { methodName: POST_UPGRADE, args: upgradeArgs ?? [ZERO_BYTES] } }
     };
 
     const res = await deployContract(name, {
-        contract: contractArtifactData || contractName,
+        contract: contractArtifactData ?? contractName,
         from,
         value,
         args,
@@ -453,7 +453,7 @@ export const upgradeProxy = async (options: UpgradeProxyOptions) => {
     console.log(`upgraded proxy ${contractName} V${prevVersion} to V${newVersion}`);
 
     const data = { name, contract: contractName };
-    saveTypes(data);
+    await saveTypes(data);
 
     await verifyTenderlyFork({
         address: res.address,
@@ -482,7 +482,7 @@ export const execute = async (options: ExecuteOptions) => {
         name,
         { from, value, waitConfirmations: WAIT_CONFIRMATIONS, log: true },
         methodName,
-        ...(args || [])
+        ...(args ?? [])
     );
 };
 
@@ -559,12 +559,12 @@ interface Deployment {
 export const save = async (deployment: Deployment) => {
     const { name, contract, address, proxy, skipVerification, skipTypechain } = deployment;
 
-    const contractName = contract || name;
+    const contractName = contract ?? name;
     const { abi } = await getExtendedArtifact(contractName);
 
     // save the typechain for future use
     if (!skipTypechain) {
-        saveTypes({ name, contract: contractName });
+        await saveTypes({ name, contract: contractName });
     }
 
     // save the deployment json data in the deployments folder
@@ -607,7 +607,7 @@ const verifyTenderlyFork = async (deployment: Deployment) => {
     }
 
     contracts.push({
-        name: contract || name,
+        name: contract ?? name,
         address: contractAddress
     });
 
@@ -620,7 +620,7 @@ const verifyTenderlyFork = async (deployment: Deployment) => {
     }
 };
 
-export const deploymentTagExists = async (tag: string) => {
+export const deploymentTagExists = (tag: string) => {
     const externalDeployments = (ExternalContracts.deployments as Record<string, string[]>)[getNetworkName()];
     const migrationsPath = path.resolve(
         __dirname,


### PR DESCRIPTION
- `no-floating-promises`: prevents unresolved promises (such as forgetting an `await` or not returning a promise from an `async` function
- `prefer-nullish-coalescing`: prefer chaining parameters using `??` instead of `||` (so that both of the vars checked for type compatibility)