### PR TITLE
Add a custom logger + enable no-console eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
         "no-loop-func": "off",
         "no-unused-expressions": "off",
         "mocha/no-exclusive-tests": "error",
+        "no-console": "error",
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/components/Profiler.ts
+++ b/components/Profiler.ts
@@ -1,4 +1,5 @@
 import { getTransactionGas } from '../test/helpers/Utils';
+import Logger from '../utils/Logger';
 import { ContractTransaction } from 'ethers';
 import { mean } from 'lodash';
 
@@ -11,7 +12,7 @@ export class Profiler {
         const res = await tx;
 
         const gas = await getTransactionGas(res);
-        console.log(`${description}: ${gas}`);
+        Logger.log(`${description}: ${gas}`);
 
         this.summary[description] ||= [];
 
@@ -21,11 +22,11 @@ export class Profiler {
     }
 
     printSummary() {
-        console.log();
-        console.log('Summary:');
+        Logger.log();
+        Logger.log('Summary:');
 
         for (const [desc, samples] of Object.entries(this.summary)) {
-            console.log(`${desc},${mean(samples)}`);
+            Logger.log(`${desc},${mean(samples)}`);
         }
     }
 }

--- a/deploy/scripts/000035-pause-legacy-programs.ts
+++ b/deploy/scripts/000035-pause-legacy-programs.ts
@@ -37,8 +37,6 @@ const func: DeployFunction = async ({ getNamedAccounts }: HardhatRuntimeEnvironm
     const { timestamp: now } = await ethers.provider.getBlock('latest');
 
     for (const poolToken of PROGRAMS_POOL_TOKENS) {
-        console.log(`Updating legacy program for ${poolToken}`);
-
         await execute({
             name: InstanceName.StakingRewardsStore,
             methodName: 'setPoolProgramEndTime',

--- a/deploy/tests/_setup.ts
+++ b/deploy/tests/_setup.ts
@@ -1,4 +1,5 @@
 import { createTenderlyFork, deleteTenderlyFork, getForkId, isTenderlyFork } from '../../utils/Deploy';
+import Logger from '../../utils/Logger';
 
 interface EnvOptions {
     TENDERLY_TEMP_PROJECT: string;
@@ -17,8 +18,8 @@ before(async () => {
 });
 
 after(async () => {
-    console.log(`Deleting temporary fork: ${getForkId()}`);
-    console.log();
+    Logger.log(`Deleting temporary fork: ${getForkId()}`);
+    Logger.log();
 
     return deleteTenderlyFork({ projectName: TENDERLY_TEMP_PROJECT });
 });

--- a/deployments/setup-fork.ts
+++ b/deployments/setup-fork.ts
@@ -8,6 +8,7 @@ import {
     isTenderlyFork,
     runPendingDeployments
 } from '../utils/Deploy';
+import Logger from '../utils/Logger';
 import { NATIVE_TOKEN_ADDRESS } from '../utils/TokenData';
 import { toWei } from '../utils/Types';
 import '@nomiclabs/hardhat-ethers';
@@ -43,7 +44,7 @@ interface FundingRequest {
 }
 
 const fundAccount = async (account: string, fundingRequests: FundingRequest[]) => {
-    console.log(`Funding ${account}...`);
+    Logger.log(`Funding ${account}...`);
 
     for (const fundingRequest of fundingRequests) {
         if (fundingRequest.token === NATIVE_TOKEN_ADDRESS) {
@@ -61,8 +62,8 @@ const fundAccount = async (account: string, fundingRequests: FundingRequest[]) =
 };
 
 const fundAccounts = async () => {
-    console.log('Funding test accounts...');
-    console.log();
+    Logger.log('Funding test accounts...');
+    Logger.log();
 
     const { dai, link } = await getNamedAccounts();
     const { ethWhale, bntWhale, daiWhale, linkWhale } = await getNamedSigners();
@@ -102,12 +103,12 @@ const fundAccounts = async () => {
         await fundAccount(account, fundingRequests);
     }
 
-    console.log();
+    Logger.log();
 };
 
 const removeDepositLimits = async (tokens: string[]) => {
-    console.log('Removing deposit limits...');
-    console.log();
+    Logger.log('Removing deposit limits...');
+    Logger.log();
 
     const { daoMultisig } = await getNamedSigners();
 
@@ -118,8 +119,8 @@ const removeDepositLimits = async (tokens: string[]) => {
 };
 
 const setLockDuration = async (lockDuration: number) => {
-    console.log(`Setting withdrawal lock duration to ${lockDuration} seconds...`);
-    console.log();
+    Logger.log(`Setting withdrawal lock duration to ${lockDuration} seconds...`);
+    Logger.log();
 
     const { daoMultisig } = await getNamedSigners();
 
@@ -128,12 +129,12 @@ const setLockDuration = async (lockDuration: number) => {
 };
 
 const runDeployments = async () => {
-    console.log('Running pending deployments...');
-    console.log();
+    Logger.log('Running pending deployments...');
+    Logger.log();
 
     await runPendingDeployments();
 
-    console.log();
+    Logger.log();
 };
 
 const archiveArtifacts = async () => {
@@ -145,8 +146,8 @@ const archiveArtifacts = async () => {
     zip.addLocalFolder(srcDir);
     zip.writeZip(dest);
 
-    console.log(`Archived ${srcDir} to ${dest}...`);
-    console.log();
+    Logger.log(`Archived ${srcDir} to ${dest}...`);
+    Logger.log();
 };
 
 const main = async () => {
@@ -154,7 +155,7 @@ const main = async () => {
         throw new Error('Invalid network');
     }
 
-    console.log();
+    Logger.log();
 
     await createTenderlyFork();
 
@@ -176,24 +177,24 @@ const main = async () => {
     const description = `${FORK_NAME} Fork`;
     const forkId = getForkId();
 
-    console.log('********************************************************************************');
-    console.log();
-    console.log(description);
-    console.log('‾'.repeat(description.length));
-    console.log(`   RPC: https://rpc.tenderly.co/fork/${forkId}`);
-    console.log(`   Dashboard: https://dashboard.tenderly.co/${TENDERLY_USERNAME}/${TENDERLY_PROJECT}/fork/${forkId}`);
+    Logger.log('********************************************************************************');
+    Logger.log();
+    Logger.log(description);
+    Logger.log('‾'.repeat(description.length));
+    Logger.log(`   RPC: https://rpc.tenderly.co/fork/${forkId}`);
+    Logger.log(`   Dashboard: https://dashboard.tenderly.co/${TENDERLY_USERNAME}/${TENDERLY_PROJECT}/fork/${forkId}`);
     if (isResearch) {
-        console.log();
-        console.log(`   * Unlimited deposits`);
-        console.log(`   * Withdrawal locking duration was set to ${lockDuration} seconds`);
+        Logger.log();
+        Logger.log(`   * Unlimited deposits`);
+        Logger.log(`   * Withdrawal locking duration was set to ${lockDuration} seconds`);
     }
-    console.log();
-    console.log('********************************************************************************');
+    Logger.log();
+    Logger.log('********************************************************************************');
 };
 
 main()
     .then(() => process.exit(0))
     .catch((error) => {
-        console.error(error);
+        Logger.error(error);
         process.exit(1);
     });

--- a/scripts/example.ts
+++ b/scripts/example.ts
@@ -1,6 +1,7 @@
 import Contracts from '../components/Contracts';
 import { MAX_UINT256, ZERO_ADDRESS } from '../utils/Constants';
 import { DeployedContracts, getNamedSigners, isTenderlyFork } from '../utils/Deploy';
+import Logger from '../utils/Logger';
 import '@nomiclabs/hardhat-ethers';
 import '@typechain/hardhat';
 import { getNamedAccounts } from 'hardhat';
@@ -20,27 +21,27 @@ const main = async () => {
     const linkToken = await Contracts.ERC20.attach(link);
     const amount = 5000;
 
-    console.log('Previous LINK balance', (await linkToken.balanceOf(linkWhale.address)).toString());
-    console.log('Previous BNT balance', (await bnt.balanceOf(linkWhale.address)).toString());
+    Logger.log('Previous LINK balance', (await linkToken.balanceOf(linkWhale.address)).toString());
+    Logger.log('Previous BNT balance', (await bnt.balanceOf(linkWhale.address)).toString());
 
-    console.log();
+    Logger.log();
 
     await linkToken.connect(linkWhale).approve(network.address, amount);
     const res = await network
         .connect(linkWhale)
         .tradeBySourceAmount(linkToken.address, bnt.address, amount, 1, MAX_UINT256, ZERO_ADDRESS);
 
-    console.log('Transaction Hash', res.hash);
-    console.log();
+    Logger.log('Transaction Hash', res.hash);
+    Logger.log();
 
-    console.log('Current LINK balance', (await linkToken.balanceOf(linkWhale.address)).toString());
-    console.log('Current BNT balance', (await bnt.balanceOf(linkWhale.address)).toString());
-    console.log();
+    Logger.log('Current LINK balance', (await linkToken.balanceOf(linkWhale.address)).toString());
+    Logger.log('Current BNT balance', (await bnt.balanceOf(linkWhale.address)).toString());
+    Logger.log();
 };
 
 main()
     .then(() => process.exit(0))
     .catch((error) => {
-        console.error(error);
+        Logger.error(error);
         process.exit(1);
     });

--- a/scripts/timer.ts
+++ b/scripts/timer.ts
@@ -1,4 +1,5 @@
 import { getNamedSigners, isTenderlyFork } from '../utils/Deploy';
+import Logger from '../utils/Logger';
 import { toWei } from '../utils/Types';
 import '@nomiclabs/hardhat-ethers';
 import '@typechain/hardhat';
@@ -19,9 +20,9 @@ const main = async () => {
         try {
             const { timestamp, number } = await ethers.provider.getBlock('latest');
 
-            console.log(`Current block=${number}, timestamp=${timestamp}`);
-            console.log(`Waiting for ${TIMEOUT / 1000} seconds...`);
-            console.log('');
+            Logger.log(`Current block=${number}, timestamp=${timestamp}`);
+            Logger.log(`Waiting for ${TIMEOUT / 1000} seconds...`);
+            Logger.log('');
 
             await setTimeout(TIMEOUT);
 
@@ -30,8 +31,8 @@ const main = async () => {
                 to: ethWhale.address
             });
         } catch (e: unknown) {
-            console.error(`Failed with: ${e}. Resuming in ${TIMEOUT / 1000} seconds...`);
-            console.error('');
+            Logger.error(`Failed with: ${e}. Resuming in ${TIMEOUT / 1000} seconds...`);
+            Logger.error('');
 
             await setTimeout(TIMEOUT);
         }
@@ -41,6 +42,6 @@ const main = async () => {
 main()
     .then(() => process.exit(0))
     .catch((error) => {
-        console.error(error);
+        Logger.error(error);
         process.exit(1);
     });

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -29,6 +29,7 @@ import {
 import LegacyContractsV3, { PoolCollectionType1V1 } from '../../components/LegacyContractsV3';
 import { TradeAmountAndFeeStructOutput } from '../../typechain-types/contracts/helpers/TestPoolCollection';
 import { MAX_UINT256, PPM_RESOLUTION, ZERO_ADDRESS, ZERO_BYTES } from '../../utils/Constants';
+import Logger from '../../utils/Logger';
 import { permitSignature } from '../../utils/Permit';
 import { DEFAULT_DECIMALS, NATIVE_TOKEN_ADDRESS, TokenData, TokenSymbol } from '../../utils/TokenData';
 import { fromPPM, toPPM, toWei } from '../../utils/Types';
@@ -4191,7 +4192,7 @@ describe('BancorNetwork Financial Verification', () => {
 
     const execute = async () => {
         for (const [n, { type, userId, amount, mined, expected }] of flow.operations.entries()) {
-            console.log(`${n + 1} out of ${flow.operations.length}: ${type}(${amount})`);
+            Logger.log(`${n + 1} out of ${flow.operations.length}: ${type}(${amount})`);
 
             if (mined) {
                 await poolCollection.setBlockNumber(++blockNumber);

--- a/test/network/PendingWithdrawals.ts
+++ b/test/network/PendingWithdrawals.ts
@@ -560,7 +560,9 @@ describe('PendingWithdrawals', () => {
                         });
 
                         it('should revert when attempting to complete a withdrawal request', async () => {
-                            await expect(testCompleteWithdrawal()).to.be.revertedWith('WithdrawalNotAllowed');
+                            await expect(
+                                network.completeWithdrawalT(CONTEXT_ID, provider.address, id)
+                            ).to.be.revertedWith('WithdrawalNotAllowed');
                         });
                     });
 

--- a/utils/Deploy.ts
+++ b/utils/Deploy.ts
@@ -45,6 +45,7 @@ import {
     StandardRewardsV2
 } from '../components/LegacyContractsV3';
 import { ExternalContracts } from '../deployments/data';
+import Logger from '../utils/Logger';
 import { DeploymentNetwork, ZERO_BYTES } from './Constants';
 import { RoleIds } from './Roles';
 import { toWei } from './Types';
@@ -216,8 +217,8 @@ export const createTenderlyFork = async (options: CreateForkOptions = { projectN
     forkId = tenderlyNetwork.getFork()!;
     tenderlyNetwork.setFork(forkId);
 
-    console.log(`Created temporary fork: ${forkId}`);
-    console.log();
+    Logger.log(`Created temporary fork: ${forkId}`);
+    Logger.log();
 
     const networkConfig = network.config as HttpNetworkUserConfig;
     networkConfig.url = `https://rpc.tenderly.co/fork/${forkId}`;
@@ -377,9 +378,9 @@ export const deploy = async (options: DeployOptions) => {
             execute: proxy.skipInitialization ? undefined : { init: { methodName: INITIALIZE, args: [] } }
         };
 
-        console.log(`deploying proxy ${contractName}${customAlias}`);
+        Logger.log(`deploying proxy ${contractName}${customAlias}`);
     } else {
-        console.log(`deploying ${contractName}${customAlias}`);
+        Logger.log(`deploying ${contractName}${customAlias}`);
     }
 
     const res = await deployContract(name, {
@@ -450,7 +451,7 @@ export const upgradeProxy = async (options: UpgradeProxyOptions) => {
 
     const newVersion = await (deployed as IVersioned).version();
 
-    console.log(`upgraded proxy ${contractName} V${prevVersion} to V${newVersion}`);
+    Logger.log(`upgraded proxy ${contractName} V${prevVersion} to V${newVersion}`);
 
     const data = { name, contract: contractName };
     await saveTypes(data);
@@ -496,7 +497,7 @@ interface InitializeProxyOptions {
 export const initializeProxy = async (options: InitializeProxyOptions) => {
     const { name, proxyName, args, from } = options;
 
-    console.log(`initializing proxy ${name}`);
+    Logger.log(`initializing proxy ${name}`);
 
     await execute({
         name: proxyName,
@@ -614,7 +615,7 @@ const verifyTenderlyFork = async (deployment: Deployment) => {
     tenderlyNetwork.setHead('');
 
     for (const contract of contracts) {
-        console.log('verifying on tenderly', contract.name, 'at', contract.address);
+        Logger.log('verifying on tenderly', contract.name, 'at', contract.address);
 
         await tenderlyNetwork.verify(contract);
     }

--- a/utils/Logger.ts
+++ b/utils/Logger.ts
@@ -1,0 +1,1 @@
+export default console;


### PR DESCRIPTION
The goal of this PR is to stop using `console.log` for system logging, which will help us to maintain and improve existing logging