### PR TITLE
Add fee exemption whitelist

### DIFF
--- a/contracts/helpers/TestBancorNetwork.sol
+++ b/contracts/helpers/TestBancorNetwork.sol
@@ -31,7 +31,6 @@ contract TestBancorNetwork is BancorNetwork, TestTime {
         IMasterVault initMasterVault,
         IExternalProtectionVault initExternalProtectionVault,
         IPoolToken initBNTPoolToken,
-        address bancorArbitrage,
         address carbonPOL
     )
         BancorNetwork(
@@ -41,7 +40,6 @@ contract TestBancorNetwork is BancorNetwork, TestTime {
             initMasterVault,
             initExternalProtectionVault,
             initBNTPoolToken,
-            bancorArbitrage,
             carbonPOL
         )
     {}

--- a/contracts/network/BancorNetwork.sol
+++ b/contracts/network/BancorNetwork.sol
@@ -926,21 +926,6 @@ contract BancorNetwork is IBancorNetwork, Upgradeable, ReentrancyGuardUpgradeabl
     }
 
     /**
-     * @dev adds multiple addresses to the fee exemption whitelist
-     *
-     * requirements:
-     *
-     * - the caller must be the admin of the contract
-     */
-    function addAddressesToWhitelist(address[] calldata addrs) external onlyAdmin {
-        uint256 length = addrs.length;
-
-        for (uint256 i = 0; i < length; ++i) {
-            _addToWhitelist(addrs[i]);
-        }
-    }
-
-    /**
      * @dev removes an address from the fee exemption whitelist
      *
      * requirements:

--- a/contracts/network/interfaces/IBancorNetwork.sol
+++ b/contracts/network/interfaces/IBancorNetwork.sol
@@ -162,7 +162,7 @@ interface IBancorNetwork is IUpgradeable {
      *
      * - the caller must have approved the network to transfer the source tokens on its behalf (except for in the
      *   native token case)
-     * - the caller must be the _bancorArbitrage contract
+     * - the caller must be in the fee exemption whitelist
      */
     function tradeBySourceAmountArb(
         Token sourceToken,
@@ -181,7 +181,7 @@ interface IBancorNetwork is IUpgradeable {
      *
      * - the caller must have approved the network to transfer the source tokens on its behalf (except for in the
      *   native token case)
-     * - the caller must be the _bancorArbitrage contract
+     * - the caller must be in the fee exemption whitelist
      */
     function tradeByTargetAmountArb(
         Token sourceToken,
@@ -227,4 +227,14 @@ interface IBancorNetwork is IUpgradeable {
      * and disables trading on the given pool if it is not already disabled
      */
     function withdrawPOL(Token pool) external returns (uint256);
+
+    /**
+     * @dev returns whether an address is in the fee exemption whitelist
+     */
+    function isWhitelisted(address _address) external view returns (bool);
+
+    /**
+     * @dev returns the fee exemption whitelist
+     */
+    function feeExemptionWhitelist() external view returns (address[] memory);
 }

--- a/deploy/scripts/000065-upgrade-network-v11.ts
+++ b/deploy/scripts/000065-upgrade-network-v11.ts
@@ -1,0 +1,42 @@
+import { DeployedContracts, execute, InstanceName, setDeploymentMetadata, upgradeProxy } from '../../utils/Deploy';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+const func: DeployFunction = async ({ getNamedAccounts }: HardhatRuntimeEnvironment) => {
+    const { deployer, bancorArbitrageAddress, carbonPOLAddress } = await getNamedAccounts();
+
+    // get the deployed contracts
+    const externalProtectionVault = await DeployedContracts.ExternalProtectionVault.deployed();
+    const masterVault = await DeployedContracts.MasterVault.deployed();
+    const networkSettings = await DeployedContracts.NetworkSettings.deployed();
+    const bntGovernance = await DeployedContracts.BNTGovernance.deployed();
+    const vbntGovernance = await DeployedContracts.VBNTGovernance.deployed();
+    const bnBNT = await DeployedContracts.bnBNT.deployed();
+
+    // upgrade the BancorNetwork contract
+    await upgradeProxy({
+        name: InstanceName.BancorNetwork,
+        args: [
+            bntGovernance.address,
+            vbntGovernance.address,
+            networkSettings.address,
+            masterVault.address,
+            externalProtectionVault.address,
+            bnBNT.address,
+            carbonPOLAddress
+        ],
+        from: deployer
+    });
+
+    // add bancor arbitrage contract address to fee exemption whitelist
+    await execute({
+        name: InstanceName.BancorNetwork,
+        methodName: 'addToWhitelist',
+        args: [bancorArbitrageAddress],
+        from: deployer
+    });
+
+    return true;
+};
+
+export default setDeploymentMetadata(__filename, func);

--- a/deploy/tests/000065-upgrade-network-v11.ts
+++ b/deploy/tests/000065-upgrade-network-v11.ts
@@ -1,0 +1,26 @@
+import { BancorNetwork } from '../../components/Contracts';
+import { describeDeployment } from '../../test/helpers/Deploy';
+import { DeployedContracts } from '../../utils/Deploy';
+import { toWei } from '../../utils/Types';
+import { expect } from 'chai';
+import { getNamedAccounts } from 'hardhat';
+
+describeDeployment(__filename, () => {
+    let network: BancorNetwork;
+
+    beforeEach(async () => {
+        network = await DeployedContracts.BancorNetwork.deployed();
+    });
+
+    it('should upgrade the network contract properly', async () => {
+        expect(await network.version()).to.equal(11);
+        expect(await network.minNetworkFeeBurn()).to.equal(toWei(1_000_000));
+    });
+
+    it('should have added bancor arbitrage contract address to fee exemption whitelist', async () => {
+        const { bancorArbitrageAddress } = await getNamedAccounts();
+
+        const whitelist = await network.feeExemptionWhitelist();
+        expect(whitelist).to.include(bancorArbitrageAddress);
+    });
+});

--- a/deployments/run-fork.sh
+++ b/deployments/run-fork.sh
@@ -12,18 +12,6 @@ else
     project=${TENDERLY_PROJECT}
 fi
 
-# Read the network name from the environment variable, default to 'mainnet' if not set
-network_name=${TENDERLY_NETWORK_NAME:-'mainnet'}
-
-# Check if network_id is null or empty
-if [ -z "$network_id" ] || [ "$network_id" == "null" ]; then
-    # Fallback to the default network ID
-    network_id=${TENDERLY_NETWORK_ID:-"1"}
-fi
-
-echo "Creating a $network_name Tenderly Fork with Chain Id $network_id... "
-echo
-
 TENDERLY_FORK_API="https://api.tenderly.co/api/v1/account/${username}/project/${project}/fork"
 
 cleanup() {
@@ -40,26 +28,12 @@ trap cleanup TERM EXIT
 
 fork_id=$(curl -sX POST "${TENDERLY_FORK_API}" \
     -H "Content-Type: application/json" -H "X-Access-Key: ${TENDERLY_ACCESS_KEY}" \
-    -d '{"network_id": "'${network_id}'"}' | jq -r '.simulation_fork.id')
+    -d '{"network_id": "1"}' | jq -r '.simulation_fork.id')
 
-echo "Created Tenderly Fork ${fork_id} at ${username}/${project}..."
+echo "Created a fork ${fork_id} at ${username}/${project}..."
 echo
 
-# if deployments/${network_name} doesn't exist, create it and create a .chainId file
-if [ ! -d "./deployments/${network_name}" ]; then
-    mkdir -p ./deployments/${network_name}
-    echo ${network_id} > ./deployments/${network_name}/.chainId
-fi
-
-# if deploy/scripts/${network_name} doesn't exist, create it and copy the network scripts
-if [ ! -d "./deploy/scripts/${network_name}" ]; then
-    rsync -a --delete ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
-fi
-
-# Create a new dir for the deploy script files and copy them there
-rm -rf deployments/tenderly && cp -rf deployments/${network_name}/. deployments/tenderly
-
-command="TENDERLY_FORK_ID=${fork_id} TENDERLY_NETWORK_NAME=${network_name} ${@:1}"
+command="TENDERLY_FORK_ID=${fork_id} ${@:1}"
 
 echo "Running:"
 echo

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -124,7 +124,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 200
+                        runs: 180
                     },
                     metadata: {
                         bytecodeHash: 'none'

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -124,7 +124,7 @@ const config: HardhatUserConfig = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 180
+                        runs: 200
                     },
                     metadata: {
                         bytecodeHash: 'none'

--- a/test/helpers/Factory.ts
+++ b/test/helpers/Factory.ts
@@ -291,7 +291,6 @@ const createNetwork = async (
     masterVault: MasterVault,
     externalProtectionVault: ExternalProtectionVault,
     bntPoolToken: PoolToken,
-    bancorArbitrageAddress: string,
     carbonPOLAddress: string
 ) => {
     const network = await createProxy(Contracts.TestBancorNetwork, {
@@ -303,7 +302,6 @@ const createNetwork = async (
             masterVault.address,
             externalProtectionVault.address,
             bntPoolToken.address,
-            bancorArbitrageAddress,
             carbonPOLAddress
         ]
     });
@@ -337,12 +335,6 @@ const createSystemFixture = async () => {
 
     const networkSettings = await createProxy(Contracts.NetworkSettings, { ctorArgs: [bnt.address] });
 
-    // Pre-calculated arb contract address
-    // Used to avoid cyclical immutable dependencies
-    // (The network contract requires arb contract's address and
-    // the arb contract requires the network's address at construction time)
-    const bancorArbitrageAddress = '0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3';
-
     const carbonPOL = await createProxy(Contracts.MockCarbonPOL, { skipInitialization: true });
 
     const network = await createNetwork(
@@ -352,7 +344,6 @@ const createSystemFixture = async () => {
         masterVault,
         externalProtectionVault,
         bntPoolToken,
-        bancorArbitrageAddress,
         carbonPOL.address
     );
 

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -3378,43 +3378,6 @@ describe('BancorNetwork', () => {
                 expect(await network.isWhitelisted(user1.address)).to.be.true;
                 expect(await network.feeExemptionWhitelist()).to.include(user1.address);
             });
-
-            it('should revert when a non-admin attempts to add addresses', async () => {
-                await expect(
-                    network.connect(nonOwner).addAddressesToWhitelist([user1.address])
-                ).to.be.revertedWithError('AccessDenied');
-            });
-
-            it('should revert when adding invalid addresses', async () => {
-                await expect(network.addAddressesToWhitelist([ZERO_ADDRESS])).to.be.revertedWithError(
-                    'InvalidExternalAddress'
-                );
-            });
-
-            it('should revert when adding already whitelisted addresses in the same transaction', async () => {
-                await expect(network.addAddressesToWhitelist([user1.address, user1.address])).to.be.revertedWithError(
-                    'AlreadyExists'
-                );
-            });
-
-            it('should revert when adding already whitelisted addresses in different transactions', async () => {
-                await network.addAddressesToWhitelist([user1.address]);
-                await expect(network.addAddressesToWhitelist([user1.address])).to.be.revertedWithError('AlreadyExists');
-            });
-
-            it('should whitelist addresses', async () => {
-                expect(await network.isWhitelisted(user1.address)).to.be.false;
-                expect(await network.isWhitelisted(user2.address)).to.be.false;
-                expect(await network.feeExemptionWhitelist()).not.to.have.members([user1.address, user2.address]);
-
-                const res = await network.addAddressesToWhitelist([user1.address, user2.address]);
-                await expect(res).to.emit(network, 'AddressAddedToWhitelist').withArgs(user1.address);
-                await expect(res).to.emit(network, 'AddressAddedToWhitelist').withArgs(user2.address);
-
-                expect(await network.isWhitelisted(user1.address)).to.be.true;
-                expect(await network.isWhitelisted(user2.address)).to.be.true;
-                expect(await network.feeExemptionWhitelist()).to.have.members([user1.address, user2.address]);
-            });
         });
 
         describe('removing', () => {

--- a/test/network/BancorNetwork.ts
+++ b/test/network/BancorNetwork.ts
@@ -22,13 +22,7 @@ import Contracts, {
 import { TokenGovernance } from '../../components/LegacyContracts';
 import LegacyContractsV3, { PoolCollectionType1V11 } from '../../components/LegacyContractsV3';
 import { TradeAmountAndFeeStructOutput } from '../../typechain-types/contracts/pools/PoolCollection';
-import {
-    ARB_CONTRACT_TEST_ADDRESS,
-    MAX_UINT256,
-    PPM_RESOLUTION,
-    ZERO_ADDRESS,
-    ZERO_BYTES
-} from '../../utils/Constants';
+import { MAX_UINT256, PPM_RESOLUTION, ZERO_ADDRESS, ZERO_BYTES } from '../../utils/Constants';
 import Logger from '../../utils/Logger';
 import { DEFAULT_DECIMALS, NATIVE_TOKEN_ADDRESS, TokenData, TokenSymbol } from '../../utils/TokenData';
 import { percentsToPPM, toPPM, toWei } from '../../utils/Types';
@@ -155,7 +149,6 @@ describe('BancorNetwork', () => {
                     masterVault.address,
                     externalProtectionVault.address,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     carbonPOL.address
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -170,7 +163,6 @@ describe('BancorNetwork', () => {
                     masterVault.address,
                     externalProtectionVault.address,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     carbonPOL.address
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -185,7 +177,6 @@ describe('BancorNetwork', () => {
                     masterVault.address,
                     externalProtectionVault.address,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     carbonPOL.address
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -200,7 +191,6 @@ describe('BancorNetwork', () => {
                     ZERO_ADDRESS,
                     externalProtectionVault.address,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     carbonPOL.address
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -217,7 +207,6 @@ describe('BancorNetwork', () => {
                     masterVault.address,
                     ZERO_ADDRESS,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     carbonPOL.address
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -231,22 +220,6 @@ describe('BancorNetwork', () => {
                     networkSettings.address,
                     masterVault.address,
                     externalProtectionVault.address,
-                    ZERO_ADDRESS,
-                    ARB_CONTRACT_TEST_ADDRESS,
-                    carbonPOL.address
-                )
-            ).to.be.revertedWithError('InvalidAddress');
-        });
-
-        it('should revert when attempting to create with an invalid arb contract', async () => {
-            await expect(
-                Contracts.BancorNetwork.deploy(
-                    bntGovernance.address,
-                    vbntGovernance.address,
-                    networkSettings.address,
-                    masterVault.address,
-                    externalProtectionVault.address,
-                    bntPoolToken.address,
                     ZERO_ADDRESS,
                     carbonPOL.address
                 )
@@ -262,7 +235,6 @@ describe('BancorNetwork', () => {
                     masterVault.address,
                     externalProtectionVault.address,
                     bntPoolToken.address,
-                    ARB_CONTRACT_TEST_ADDRESS,
                     ZERO_ADDRESS
                 )
             ).to.be.revertedWithError('InvalidAddress');
@@ -276,7 +248,6 @@ describe('BancorNetwork', () => {
                 masterVault.address,
                 externalProtectionVault.address,
                 bntPoolToken.address,
-                ARB_CONTRACT_TEST_ADDRESS,
                 carbonPOL.address
             );
 
@@ -293,7 +264,6 @@ describe('BancorNetwork', () => {
                 masterVault.address,
                 externalProtectionVault.address,
                 bntPoolToken.address,
-                ARB_CONTRACT_TEST_ADDRESS,
                 carbonPOL.address
             );
 
@@ -310,7 +280,6 @@ describe('BancorNetwork', () => {
                 masterVault.address,
                 externalProtectionVault.address,
                 bntPoolToken.address,
-                ARB_CONTRACT_TEST_ADDRESS,
                 carbonPOL.address
             );
 
@@ -326,7 +295,7 @@ describe('BancorNetwork', () => {
         });
 
         it('should be properly initialized', async () => {
-            expect(await network.version()).to.equal(10);
+            expect(await network.version()).to.equal(11);
 
             await expectRoles(network, Roles.BancorNetwork);
 
@@ -2686,13 +2655,13 @@ describe('BancorNetwork', () => {
                         });
 
                         context('arb contract trades', () => {
-                            it('should revert when attempting to call tradeBySourceAmountArb from address other than arb contract', async () => {
+                            it('should revert when attempting to call tradeBySourceAmountArb from non-whitelisted address', async () => {
                                 await expect(tradeBySourceAmountArb(testAmount)).to.be.revertedWithError(
                                     'AccessDenied'
                                 );
                             });
 
-                            it('should revert when attempting to call tradeByTargetAmountArb from address other than arb contract', async () => {
+                            it('should revert when attempting to call tradeByTargetAmountArb from non-whitelisted address', async () => {
                                 await expect(tradeByTargetAmountArb(testAmount)).to.be.revertedWithError(
                                     'AccessDenied'
                                 );
@@ -2924,7 +2893,7 @@ describe('BancorNetwork', () => {
             });
         });
 
-        const testFlashLoan = (tokenData: TokenData, flashLoanFeePPM: number) => {
+        const testFlashLoan = (tokenData: TokenData, flashLoanFeePPM: number, isWhitelisted: boolean) => {
             const FEE_AMOUNT = LOAN_AMOUNT.mul(flashLoanFeePPM).div(PPM_RESOLUTION);
 
             beforeEach(async () => {
@@ -2986,17 +2955,33 @@ describe('BancorNetwork', () => {
             });
 
             if (flashLoanFeePPM > 0) {
-                context('not repaying the fee', () => {
-                    beforeEach(async () => {
-                        await recipient.setAmountToReturn(LOAN_AMOUNT);
-                    });
+                if (isWhitelisted) {
+                    context('not repaying the fee', () => {
+                        beforeEach(async () => {
+                            await recipient.setAmountToReturn(LOAN_AMOUNT);
+                            // whitelist deployer
+                            await network.addToWhitelist(deployer.address);
+                        });
 
-                    it('should revert when attempting to request a flash-loan', async () => {
-                        await expect(
-                            network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, ZERO_BYTES)
-                        ).to.be.revertedWithError('InsufficientFlashLoanReturn');
+                        it('should succeed requesting a flash-loan', async () => {
+                            await expect(
+                                network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, ZERO_BYTES)
+                            ).not.to.be.revertedWithError('InsufficientFlashLoanReturn');
+                        });
                     });
-                });
+                } else {
+                    context('not repaying the fee', () => {
+                        beforeEach(async () => {
+                            await recipient.setAmountToReturn(LOAN_AMOUNT);
+                        });
+
+                        it('should revert when attempting to request a flash-loan', async () => {
+                            await expect(
+                                network.flashLoan(token.address, LOAN_AMOUNT, recipient.address, ZERO_BYTES)
+                            ).to.be.revertedWithError('InsufficientFlashLoanReturn');
+                        });
+                    });
+                }
             }
 
             context('repaying more than required', () => {
@@ -3027,9 +3012,11 @@ describe('BancorNetwork', () => {
 
         for (const symbol of [TokenSymbol.BNT, TokenSymbol.ETH, TokenSymbol.TKN]) {
             for (const flashLoanFee of [0, 2.5]) {
-                context(`${symbol} with fee=${flashLoanFee}%`, () => {
-                    testFlashLoan(new TokenData(symbol), toPPM(flashLoanFee));
-                });
+                for (const isWhitelisted of [true, false]) {
+                    context(`${symbol} with fee=${flashLoanFee}%, isWhitelisted=${isWhitelisted}`, () => {
+                        testFlashLoan(new TokenData(symbol), toPPM(flashLoanFee), isWhitelisted);
+                    });
+                }
             }
         }
     });
@@ -3335,6 +3322,127 @@ describe('BancorNetwork', () => {
                 it('should revert when attempting to withdraw the pending network fees', async () => {
                     await expect(network.burnNetworkFees()).to.be.revertedWithError('Pausable: paused');
                 });
+            });
+        });
+    });
+
+    describe('fee exemption whitelist', () => {
+        let network: TestBancorNetwork;
+        let networkSettings: NetworkSettings;
+
+        let emergencyStopper: SignerWithAddress;
+        let user1: SignerWithAddress;
+        let user2: SignerWithAddress;
+
+        before(async () => {
+            [, emergencyStopper, user1, user2] = await ethers.getSigners();
+        });
+
+        beforeEach(async () => {
+            ({ network, networkSettings } = await createSystem());
+
+            await networkSettings.setMinLiquidityForTrading(MIN_LIQUIDITY_FOR_TRADING);
+
+            await network
+                .connect(deployer)
+                .grantRole(Roles.BancorNetwork.ROLE_EMERGENCY_STOPPER, emergencyStopper.address);
+        });
+
+        beforeEach(async () => {
+            expect(await network.feeExemptionWhitelist()).to.be.empty;
+        });
+
+        describe('adding', () => {
+            it('should revert when a non-admin attempts to add an address', async () => {
+                await expect(network.connect(nonOwner).addToWhitelist(user1.address)).to.be.revertedWithError(
+                    'AccessDenied'
+                );
+            });
+
+            it('should revert when adding an invalid address', async () => {
+                await expect(network.addToWhitelist(ZERO_ADDRESS)).to.be.revertedWithError('InvalidExternalAddress');
+            });
+
+            it('should revert when adding an already whitelisted address', async () => {
+                await network.addToWhitelist(user1.address);
+                await expect(network.addToWhitelist(user1.address)).to.be.revertedWithError('AlreadyExists');
+            });
+
+            it('should whitelist an address', async () => {
+                expect(await network.isWhitelisted(user1.address)).to.be.false;
+                expect(await network.feeExemptionWhitelist()).not.to.include(user1.address);
+
+                const res = await network.addToWhitelist(user1.address);
+                await expect(res).to.emit(network, 'AddressAddedToWhitelist').withArgs(user1.address);
+
+                expect(await network.isWhitelisted(user1.address)).to.be.true;
+                expect(await network.feeExemptionWhitelist()).to.include(user1.address);
+            });
+
+            it('should revert when a non-admin attempts to add addresses', async () => {
+                await expect(
+                    network.connect(nonOwner).addAddressesToWhitelist([user1.address])
+                ).to.be.revertedWithError('AccessDenied');
+            });
+
+            it('should revert when adding invalid addresses', async () => {
+                await expect(network.addAddressesToWhitelist([ZERO_ADDRESS])).to.be.revertedWithError(
+                    'InvalidExternalAddress'
+                );
+            });
+
+            it('should revert when adding already whitelisted addresses in the same transaction', async () => {
+                await expect(network.addAddressesToWhitelist([user1.address, user1.address])).to.be.revertedWithError(
+                    'AlreadyExists'
+                );
+            });
+
+            it('should revert when adding already whitelisted addresses in different transactions', async () => {
+                await network.addAddressesToWhitelist([user1.address]);
+                await expect(network.addAddressesToWhitelist([user1.address])).to.be.revertedWithError('AlreadyExists');
+            });
+
+            it('should whitelist addresses', async () => {
+                expect(await network.isWhitelisted(user1.address)).to.be.false;
+                expect(await network.isWhitelisted(user2.address)).to.be.false;
+                expect(await network.feeExemptionWhitelist()).not.to.have.members([user1.address, user2.address]);
+
+                const res = await network.addAddressesToWhitelist([user1.address, user2.address]);
+                await expect(res).to.emit(network, 'AddressAddedToWhitelist').withArgs(user1.address);
+                await expect(res).to.emit(network, 'AddressAddedToWhitelist').withArgs(user2.address);
+
+                expect(await network.isWhitelisted(user1.address)).to.be.true;
+                expect(await network.isWhitelisted(user2.address)).to.be.true;
+                expect(await network.feeExemptionWhitelist()).to.have.members([user1.address, user2.address]);
+            });
+        });
+
+        describe('removing', () => {
+            beforeEach(async () => {
+                await network.addToWhitelist(user1.address);
+            });
+
+            it('should revert when a non-admin attempts to remove an address', async () => {
+                await expect(network.connect(nonOwner).removeFromWhitelist(user1.address)).to.be.revertedWithError(
+                    'AccessDenied'
+                );
+            });
+
+            it('should revert when removing a non-whitelisted token', async () => {
+                await expect(network.removeFromWhitelist(ZERO_ADDRESS)).to.be.revertedWithError('DoesNotExist');
+
+                await expect(network.removeFromWhitelist(user2.address)).to.be.revertedWithError('DoesNotExist');
+            });
+
+            it('should remove a token', async () => {
+                expect(await network.isWhitelisted(user1.address)).to.be.true;
+                expect(await network.feeExemptionWhitelist()).to.include(user1.address);
+
+                const res = await network.removeFromWhitelist(user1.address);
+                await expect(res).to.emit(network, 'AddressRemovedFromWhitelist').withArgs(user1.address);
+
+                expect(await network.isWhitelisted(user1.address)).to.be.false;
+                expect(await network.feeExemptionWhitelist()).not.to.include(user1.address);
             });
         });
     });


### PR DESCRIPTION
* Add fee exemption whitelist to Bancor V3 network contract, replacing the _bancorArbitrage immutable variable
* Any address in the fee exemption whitelist is exempt from trading and flashloan fees
* Admin can add and remove addresses from the whitelist
* Add tests
* Add deployment scripts